### PR TITLE
Zef::Test(::Result) improvements

### DIFF
--- a/lib/Zef/Net/HTTP/Client.pm6
+++ b/lib/Zef/Net/HTTP/Client.pm6
@@ -39,10 +39,6 @@ class Zef::Net::HTTP::Client {
         my $connection = self.connect($request.uri);
         $connection.send(~$request);
 
-        # todo:
-        # Change EOL to \r\n\r\n, use readline to read in the header using :enc(ascii)
-        # Read in the rest as the message-body using the appropriate encoding
-
         my $response   = Zef::Net::HTTP::Response.new(message => do { 
             my $d; while my $r = $connection.recv { $d ~= $r }; $d;
         });

--- a/lib/Zef/Net/HTTP/Request.pm6
+++ b/lib/Zef/Net/HTTP/Request.pm6
@@ -6,7 +6,7 @@ class Zef::Net::HTTP::Request {
     has $.action;
     has $.url;
     has $.uri;
-    has $!payload;
+    has $.payload;
     has $.proxy-url;
     has $.proxy-uri;
     has $!auth;
@@ -26,7 +26,6 @@ class Zef::Net::HTTP::Request {
             ~ (("\r\n" ~ "Authorization: Basic {$!auth}") if ?$!auth)
             ~   "\r\n" ~ "Connection: close\r\n\r\n"                        # last header field
             ~ ($!payload if $!payload);
-
         return $req;
     }
 }

--- a/lib/Zef/Test.pm6
+++ b/lib/Zef/Test.pm6
@@ -1,26 +1,42 @@
 use Zef::Test::Result;
 use Zef::Utils::PathTools;
 
+# Zef::Test should have $!path set to the base of a module's repo/directory. This is used for 2 things:
+# 1) Automatically grepping all `.t` files recursively.
+# 2) Setting the $CWD to run the tests in the directory they expect.
+# - :@test-files: Skip search for test files and run only these instead.
+# - :@includes: add `lib`s via -`I$include`. Defaults to `("$!path/blib", $!path/lib")`
+# 
+# method test
+# Create a supply of Zef::Test::Result objects. Each Zef::Test::Result object has a `.promise` attribute
+# that may be inspected for completion, output, and exit status. 
+
 class Zef::Test {
     has $.path;
     has @.test-files;
     has @.includes;
+    has $.results;
 
     submethod BUILD(:$!path!, :@!test-files, :@!includes) {
-        @!test-files = $!path.IO.ls(:r, :f).grep(/\.t$/);
+        @!test-files = $!path.IO.ls(:r, :f).grep(/\.t$/) unless @!test-files.elems;
         @!includes   = $*SPEC.catdir($!path, "blib"), $*SPEC.catdir($!path, "lib") unless @!includes.elems;
     }
 
     method test(Zef::Test:D: :$p6flags) {
+        # (Related to comment below in @!test-files.map) 
+        # We often need to use a relative path for some tests to pass. Ideally the tests 
+        # themselves would be improved, but changing directories will suffice for now.
         PRE   my $orig-cwd = $*CWD;
         ENTER chdir($!path);
         LEAVE chdir($orig-cwd);
 
-        my $tests = Supply.from-list: @!test-files.map(-> $file {
+        $!results = Supply.from-list: @!test-files.map(-> $file {
             # Some modules fail tests when using an absolute path, hence the seemingly unnecessary abs2rel
             my $file-rel = $*SPEC.abs2rel($file, $!path);
             my $process  = Proc::Async.new("perl6", @!includes.map({ qqw/-I$_/ }), $file-rel);
-            Zef::Test::Result.new( :$file, :$process ); # can probably ditch :$file and check $process.args
+
+            # Can probably ditch :$file and check $process.args
+            Zef::Test::Result.new(:$file, :$process); 
         });
     }
 }


### PR DESCRIPTION
Allow a tap for stdout/stderr, and log
to $.output as well. Store all Zef::Test::Result
objects inside Zef::Test.results