### PR TITLE
parallel `provides` precompilation

### DIFF
--- a/lib/Zef/Builder.pm6
+++ b/lib/Zef/Builder.pm6
@@ -1,135 +1,129 @@
 use Zef::Utils::Depends;
 use Zef::Utils::PathTools;
-
+use Zef::ProcessManager;
 
 # Provide functionality for precompiling modules
 class Zef::Builder {
+    has $.pm;
+    has $.async;
+
+    has %.meta;
+
+    has $.path;
+    has $.precomp-path;
+
+    has @.libs;
+    has @.includes is rw;
+
+    submethod BUILD(IO::Path :$!path, IO::Path :$!precomp-path, :$!pm, :@!libs is copy, :@!includes, Bool :$!async) {
+        %!meta  = %(from-json( $!path.IO.child('META.info').IO.slurp ))\
+            or die "No META file found";
+        $!precomp-path = $!path.child('blib') unless $!precomp-path;
+        
+        my @libs;
+        for (@!libs || $!path.child('lib').IO) -> $lib {
+            my $slib = $lib.IO.is-absolute ?? $lib.IO.relative($!path).IO !! $lib.IO;
+            my $blib = $!precomp-path.child($slib).relative($!path).IO;
+            @libs.unshift($blib);
+            @libs.push($slib);
+        }
+        @!libs = @libs;
+
+        $!pm = !$!pm.defined ?? Zef::ProcessManager.new(:$!async)
+                             !! $!pm.DEFINITE
+                                ?? $!pm
+                                !! ::($!pm).new;
+    }
+
     # todo: lots of cleanup/refactoring
-    method precomp(*@repos is copy, :$save-to is copy, Bool :$force) {
+    method precomp(Bool :$force, :@targets) {
+        @targets = @targets || $*VM.precomp-ext ~~ /moar/ ?? 'mbc' !! 'jar';
+
         # my $manifest  = from-json( %*CUSTOM_LIB<site>.IO.child('MANIFEST').IO.slurp );
-
-        my @results = eager gather for @repos -> $path {
-            my %meta  = %(from-json( $path.IO.child('META.info').IO.slurp ));
-
-
-            # NOTE: this may change
-            # Currently treats relative paths as relative to the current repo's path ($path).
-            # It may or may not be better to treat them as relative to the users CWD. We shall see.
-            temp $save-to = $save-to 
-                ?? ($save-to.IO.is-absolute ?? $save-to.IO !! $save-to.IO.absolute($path).IO) 
-                !! $path.IO;
-            print "===> Build directory: {$save-to.absolute}\n";
+        # NOTE: this may change
+        # Currently treats relative paths as relative to the current repo's path ($path).
+        # It may or may not be better to treat them as relative to the users CWD. We shall see.
+        print "!!!> No META.info `provides` section. Skipping.\n" and next unless %!meta<provides>.values;
+        print "===> Build directory: {$!precomp-path.abspath}\n";
+        my @provides-abspaths = %!meta<provides>.values.map({ $_.IO.absolute($!path).IO });
 
 
-            # Determine the paths where the sources are located, where the pre-compiled 
-            # code should go, and what $INC should include before pre-compiling.
+        # Build the @dep chain for the %META.<provides> by parsing the 
+        # use/require/need from the module source.
+        my @deps = extract-deps( @provides-abspaths ).list;
+        my @provides-as-deps = eager gather for @deps -> $dep-meta is rw {
+            $dep-meta.<depends> = [$dep-meta.<depends>.list.map(-> $name { 
+                %!meta.<provides>.list\
+                    .grep({ $_.key eq $name })\
+                    .map({ $_.value.IO.absolute($!path) });
+            } )];
+
+            $dep-meta.<name> = %!meta.<provides>.list\
+                .map({ $_.value.IO.absolute($!path).IO })\
+                .first({ $_ eq $dep-meta.<path>.IO.absolute($!path) });
+
+            take $dep-meta;
+        }
 
 
-            my @libs = %meta<provides>.list\
-                .grep({ $_.value.IO.absolute($path).IO.f })\
-                .map({ ($*SPEC.splitdir($_.value.IO.dirname).[0].IO // $*SPEC.curdir).IO.absolute($path) })\
-                .unique\
-                .map({ CompUnitRepo::Local::File.new($_).Str });
-
-            state @blibs.push($_) for @libs.map({  
-                my $blib = $_.IO.relative($path).IO\
-                    .parent.IO\
-                    .child('blib').IO\
-                    .child('lib').IO\
-                    .absolute($save-to);
-                CompUnitRepo::Local::File.new( $blib ).Str;
-            });
-
-            my $INC  := @blibs, @libs, @*INC;
-            my @files = %meta<provides>.list.map({ $_.value.IO.absolute($path).IO.path });
-
-            print "!!!> No files found. META.info `provides` section incorrect?" and next unless @files;
-
-            # Build the @dep chain for the %META.<provides> by parsing the 
-            # use/require/need from the module source.
-            my @provides-as-deps = eager gather for @(extract-deps( @files ).list) -> $info is rw {
-                $info.<depends> = [$info.<depends>.list.map(-> $name { 
-                    %meta.<provides>.first({ $_.key eq $name }).value 
-                } )];
-
-                $info.<name>    = %meta.<provides>.list.first({ 
-                    $_.value.IO.absolute($path).IO.path eq $info.<path>.IO.absolute($path)
-                }).value;
-
-                take $info;
-            }
+        my @targets-as-args  = @targets.map({   qqw/--target=$_/ });
+        my @libs-as-args     = @!libs.map({     qqw/-I$_/        });
+        my @includes-as-args = @!includes.map({ qqw/-I$_/        });
 
 
-            # @provides-as-deps is a partial META.info hash, so pass the $meta.<provides>
-            # Note topological-sort with no arguments will sort the class's @projects (provides in this case)
-            my @levels   = Zef::Utils::Depends.new(projects => @provides-as-deps).topological-sort;
+        # @provides-as-deps is a partial META.info hash, so pass the $meta.<provides>
+        # Note topological-sort with no arguments will sort the class's @projects (provides in this case)
+        my @levels = Zef::Utils::Depends.new(projects => @provides-as-deps).topological-sort;
 
 
-            # Create the build order for the `provides`
-            my @compiled = eager gather for @levels -> $level {
-                for $level.list -> $module-id {
-                    # Workaround for non-default precomp-path 
-                    # i.e. $out = /blib/lib/Name.pm6.ext instead of /lib/Name.pm6.ext
-                    # CompUnit was not designed to be subclassed, so this is kinda ugly.
-                    my $cu = CompUnit.new( $module-id.IO.absolute($path) ) but role { 
-                        has $!has-precomp = False;
-                        has $.build-output is rw;
-                        has $.precomp-path is rw;
+        my @curlfs;
+        # Create the build order for the `provides`
+        my @todo-processes = eager gather for @levels -> $level {
+            my @process-levels;
+            for $level.list -> $module-id {
+                my $file = $module-id.IO.absolute($!path).IO;
+                # Many tests are (incorrectly) written with the assumption the cwd is their projects base directory.
+                my $file-rel = ?$file.IO.is-relative ?? $file.IO.relative !! $file.IO.relative($!path);
 
-                        method BUILDALL(|) {
-                            my $return = callsame;
-                            $!precomp-path := pp();
-                            return $return;
-                        }
+                for @targets -> $target {
+                    my $out = "{$!precomp-path.child($file-rel)}.{$target ~~ /mbc/ ?? 'moarvm' !! 'jar'}".IO.relative($!path);
 
-                        method precomp($out, |c) {
-                            mkdirs($out.IO.dirname);
-                            $!precomp-path = $out;
-                            $!has-precomp  = callwith($out, |c);
-                        }
+                    @process-levels.push: $!pm.create(
+                        $*EXECUTABLE,
+                        @libs-as-args,
+                        @includes-as-args,
+                        "--target=$target",
+                        "--output=$out",
+                        $file-rel,
+                        :cwd($!path),
+                        :id($file-rel)
+                    );
 
-                        sub pp() is rw { # 'precomp-path'
-                            my $storage;
-                            Proxy.new: FETCH => method ()   { $storage.IO.absolute if ?$storage },
-                                       STORE => method ($p) { $storage = $p };
-                        }
-                    }
-                    
-
-                    # Relative and absolute file paths of where to *save* compiled ouput.
-                    my $new-id-rel = 'blib'.IO.child($module-id.IO.dirname)\
-                                              .child("{$module-id.IO.basename}.{$*VM.precomp-ext}").IO;
-
-                    $new-id-rel = $new-id-rel.relative if $new-id-rel.is-absolute; # todo: delete? leftovers?
-
-                    # relative to '$save-to', not relative to the repo source ($path)
-                    my $new-id-absolute = $new-id-rel.IO.absolute($save-to).IO;
-
-                    # todo: .build-output should really be a Channel/Supply to let the client
-                    # tap/receieve the output instead of just printing it (like Zef::Test)
-                    my $status = try ?$cu.precomp($new-id-absolute, :$INC, :$force);
-                    $cu.build-output  = "[{$module-id}] {'.' x 42 - $module-id.chars} ";
-                    my $output-rest   = $status ?? "ok: {$cu.precomp-path.IO.relative($save-to)}" !! "FAILED";
-                    $cu.build-output ~= $output-rest;
-                    print $cu.build-output ~ "\n";
-
-                    take $cu;
+                    @curlfs.push($out.IO.absolute($!path));
                 }
             }
 
-            # subclassing CompUnit seems to get screw when calling .new on a module 
-            # that augments core functionality (Utils::PathTools and augment IO::Path?)
-            # so we will use this structure for now instead of a custom CompUnit extension
-            take {  
-                ok           => ?(@compiled.grep({ ?$_.has-precomp }).elems == %meta<provides>.list.elems),
-                precomp-path => @blibs[0], 
-                path         => $path, 
-                curlfs       => @compiled, 
-                sources      => %meta<provides>.list,
-                module       => %meta<name>,
-            }
+            take [@process-levels];
         }
 
-        return @results;
+        # todo: re-enable parallel building via :$async flag
+        for @todo-processes -> $proc-level {
+            mkdirs($_) for $proc-level.list.map({ $!precomp-path.child($_.args[*-1].IO.parent) }).grep(!*.IO.e);
+            my @promises = eager gather for $proc-level.list -> $proc {
+                print "{$proc.file.IO.basename} {$proc.args.join(' ')}\n";
+                take $proc.start;
+            }
+            await Promise.allof(@promises) if @promises;
+        }
+
+
+        return {
+            ok           => ?$!pm.ok-all,
+            precomp-path => $!precomp-path, 
+            path         => $!path,
+            curlfs       => @curlfs.grep(*.IO.e).grep(*.IO.f), 
+            sources      => %!meta<provides>.list,
+            module       => %!meta<name>,
+        }
     }
 }

--- a/t/zef-builder.t
+++ b/t/zef-builder.t
@@ -8,31 +8,31 @@ plan 1;
 
 # Basic tests on default builder method
 subtest {
-    my $CWD     := $*CWD;
-    my $save-to := $CWD.child("test-libs_{time}{100000.rand.Int}").IO;
+    my $path    := $*CWD;
+    my $save-to := $path.child("test-libs_{time}{100000.rand.Int}").IO;
 
-    my $lib-base  = $CWD.child('lib').IO;
+    my $lib-base  = $path.child('lib').IO;
     my $blib-base = $save-to.child('blib').IO;
     LEAVE {       # Cleanup
         sleep 1;  # bug-fix for CompUnit related pipe file race
         try rm($save-to, :d, :f, :r);
     }
 
-    my @source-files  = ls($lib-base, :f, :r, d => False);
-    my @target-files = gather for @source-files.grep({ $_.IO.basename ~~ / \.pm6? $/ }) -> $file {
-        my $mod-path = $blib-base.child("{$file.IO.dirname.IO.relative}").IO;
-        my $target   = $mod-path.IO.child("{$file.IO.basename}.{$*VM.precomp-ext}").IO;
-        take $target.IO.path;
-    }
+    my @source-files = ls($lib-base, :f, :r, d => False);
+    my @target-files = @source-files\
+        .grep({ $_.IO.basename ~~ / \.pm6? $/ })\
+        .map({ $blib-base.child("{$_.IO.relative($path)}.{$*VM.precomp-ext}").IO });
 
-    my $builder = Zef::Builder.new;
-    my @results = $builder.precomp($CWD, :$save-to);
+    my $builder = Zef::Builder.new(:$path, precomp-path => $blib-base);
+    my $results = $builder.precomp(:force);
 
-    is @results.elems, 1, '1 repo';
+    ok $results;
+    ok $results.<ok>.so;
+    ok $results.<curlfs>.list.elems;
 
-    my @expecting = @results.[0].<curlfs>.list.map({ $_.precomp-path });
+    my @expected-abs-paths = $results.<curlfs>.list.map({ $_.IO.is-absolute ?? $_.IO !! $path.child($_.IO).IO });
     for @target-files -> $file {
-        ok $file.IO.absolute ~~ any(@expecting), "Found: {$file.IO.path}";
+        ok $file.IO.absolute ~~ any(@expected-abs-paths), "Found: {$file.IO.path}";
     }
 }, 'Zef::Builder';
 


### PR DESCRIPTION
--async
Precompiles a modules provides source files in
parallel while maintaining the correct build order.
Next we need to tie in the same with `depends` and
then tie it all into the parallel testing when
doing a complete install.