### PR TITLE
s/--async/--jobs=<limit>/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: perl
 perl:
     - '5.20'
 env:
-    - BACKEND=moar ASYNC=""
-    - BACKEND=moar ASYNC="--async"
-    - BACKEND=jvm  ASYNC=""
+    - BACKEND=moar JOBS=""
+    - BACKEND=moar JOBS="--jobs=4"
+    - BACKEND=jvm  JOBS=""
 matrix:
     allow_failures:
-        - env: BACKEND=jvm  ASYNC=""
+        - env: BACKEND=jvm  JOBS=""
     fast_finish: true
 sudo: false
 before_install:
@@ -20,5 +20,5 @@ install:
 script:
     - prove -j4 -v -e "perl6 -Ilib" t/ xt/
 after_success:
-    - 'if [[ $BACKEND == "moar" ]]; then perl6 -Ilib bin/zef -v --boring $ASYNC --save-to=precomp/ build; fi'
-    - 'if [[ $BACKEND == "moar" ]]; then perl6 -Iprecomp bin/zef -v --boring --lib=precomp $ASYNC install Zef; fi'
+    - 'if [[ $BACKEND == "moar" ]]; then perl6 -Ilib bin/zef -v --boring $JOBS --save-to=precomp/ build; fi'
+    - 'if [[ $BACKEND == "moar" ]]; then perl6 -Iprecomp bin/zef -v --boring --lib=precomp $JOBS install Zef; fi'

--- a/README.pod
+++ b/README.pod
@@ -98,7 +98,7 @@ Fetch, build, test, optional report, and install.
     
 B<Example>: (note parallelized output format will be improved)
 
-    $ zef -v --jobs=4 install CSV::Parser
+    $ zef -v --jobs=2 install CSV::Parser
     Initializing
     ===> Module count: 364
     ===> Filtered module count: 364
@@ -112,12 +112,12 @@ B<Example>: (note parallelized output format will be improved)
     ===> Precompiling OK for: Parser.pm
     01_multiline_csv.t  # perl6 --ll-exception -Iblib/lib -Ilib t/01_multiline_csv.t
     02_escaped_csv.t    # perl6 --ll-exception -Iblib/lib -Ilib t/02_escaped_csv.t
-    03_delimiters_csv.t # perl6 --ll-exception -Iblib/lib -Ilib t/03_delimiters_csv.t
-    04_binary_csv.t     # perl6 --ll-exception -Iblib/lib -Ilib t/04_binary_csv.t
     01_multiline_csv.t  # 1..1
     01_multiline_csv.t  # ok 1 -
+    03_delimiters_csv.t # perl6 --ll-exception -Iblib/lib -Ilib t/03_delimiters_csv.t
     02_escaped_csv.t    # 1..1
     02_escaped_csv.t    # ok 1 -
+    04_binary_csv.t     # perl6 --ll-exception -Iblib/lib -Ilib t/04_binary_csv.t
     03_delimiters_csv.t # 1..1
     03_delimiters_csv.t # ok 1 -
     04_binary_csv.t     # 1..1

--- a/README.pod
+++ b/README.pod
@@ -97,38 +97,35 @@ Fetch, build, test, optional report, and install.
     zef -v --report --jobs=4 install HTTP::Server::Threaded
     
 B<Example>: (note parallelized output format will be improved)
-    
-    $ zef -v install CSV::Parser P6TCI
-    ===> Querying Authority [done]
+
+    $ zef -v --jobs=4 install CSV::Parser
+    Initializing
+    ===> Module count: 364
+    ===> Filtered module count: 364
+    ===> Package file: /tmp/p6c-packages.1441864140.72.json
+    ===> Attempting to update via `git pull`
     ===> Fetching [done]
-    ===> Fetching OK for: CSV::Parser P6TCI
-    ===> META.info availability OK for: CSV::Parser P6TCI
-    ===> Build directory: /tmp/CSV--Parser/blib
-    Parser.pm # perl6 -I/tmp/CSV--Parser/blib/lib -I/tmp/CSV--Parser/lib -I/tmp/CSV--Parser/lib --target=mbc --output=/tmp/CSV--Parser/blib/lib/CSV/Parser.pm.moarvm lib/CSV/Parser.pm
-    ===> Build directory: /tmp/P6TCI/blib
-    P6TCI.pm6 # perl6 -I/tmp/P6TCI/blib/lib -I/tmp/P6TCI/lib -I/tmp/P6TCI/lib --target=mbc --output=/tmp/P6TCI/blib/lib/P6TCI.pm6.moarvm lib/P6TCI.pm6
-    ===> Building [done]
-    ===> Build OK for: lib/CSV/Parser.pm lib/P6TCI.pm6
+    ===> Fetching OK for: CSV::Parser
+    ===> META.info availability OK for: CSV::Parser
+    Parser.pm # perl6 -Iblib/lib -Ilib --target=mbc --output=blib/lib/CSV/Parser.pm.moarvm lib/CSV/Parser.pm
+    ===> Precompiling [done]
+    ===> Precompiling OK for: Parser.pm
     01_multiline_csv.t  # perl6 --ll-exception -Iblib/lib -Ilib t/01_multiline_csv.t
+    02_escaped_csv.t    # perl6 --ll-exception -Iblib/lib -Ilib t/02_escaped_csv.t
+    03_delimiters_csv.t # perl6 --ll-exception -Iblib/lib -Ilib t/03_delimiters_csv.t
+    04_binary_csv.t     # perl6 --ll-exception -Iblib/lib -Ilib t/04_binary_csv.t
     01_multiline_csv.t  # 1..1
     01_multiline_csv.t  # ok 1 -
-    02_escaped_csv.t    # perl6 --ll-exception -Iblib/lib  -Ilib t/02_escaped_csv.t
     02_escaped_csv.t    # 1..1
     02_escaped_csv.t    # ok 1 -
-    03_delimiters_csv.t # perl6 --ll-exception -Iblib/lib -Ilib t/03_delimiters_csv.t
     03_delimiters_csv.t # 1..1
     03_delimiters_csv.t # ok 1 -
-    04_binary_csv.t     # perl6 --ll-exception -Iblib/lib -Ilib t/04_binary_csv.t
     04_binary_csv.t     # 1..1
     04_binary_csv.t     # ok 1 -
-    00-load.t           # perl6 --ll-exception -Iblib/lib -Ilib t/00-load.t
-    00-load.t           # ok 1 - Module loaded.
-    00-load.t           # 1..1
     ===> Testing [done]
-    ===> Testing OK for: 01_multiline_csv.t 02_escaped_csv.t 03_delimiters_csv.t 04_binary_csv.t 00-load.t
+    ===> Testing OK for: 01_multiline_csv.t 02_escaped_csv.t 03_delimiters_csv.t 04_binary_csv.t
     ===> Installing [done]
-    ===> Install OK for: CSV::Parser P6TCI
-
+    ===> Install OK for: CSV::Parser
 
 =head4 B<smoke>
 

--- a/README.pod
+++ b/README.pod
@@ -49,7 +49,7 @@ Be sure your `PATH` includes the file path shown by the command below:
     zef -v look CSV::Parser
 
     # build/test/install all modules in the ecosystem
-    zef -v smoke
+    zef -v --report smoke
 
 =head2 More CLI
 
@@ -64,7 +64,7 @@ Fetch, build, test, optional report, and install.
     --report
 
     # parallel testing and precompilation
-    --async
+    --jobs=2
 
     # cut off lines that reach (our guess at) the term width in columns
     --no-wrap
@@ -94,7 +94,7 @@ Fetch, build, test, optional report, and install.
     --force
 
     # livin that multi thread life
-    zef -v --report --async install HTTP::Server::Threaded
+    zef -v --report --jobs=4 install HTTP::Server::Threaded
     
 B<Example>: (note parallelized output format will be improved)
     

--- a/README.pod
+++ b/README.pod
@@ -63,7 +63,7 @@ Fetch, build, test, optional report, and install.
     # send a test report
     --report
 
-    # parallel testing and precompilation
+    # parallel testing and precompilation (max processes/threads)
     --jobs=2
 
     # cut off lines that reach (our guess at) the term width in columns

--- a/lib/Zef/App.pm6
+++ b/lib/Zef/App.pm6
@@ -145,7 +145,7 @@ multi MAIN('uninstall', *@names, :$auth, :$ver, :$from = %*CUSTOM_LIB<site>, Boo
 
 #| Install with business logic
 multi MAIN('install', *@modules, :$lib, :$ignore, :$save-to = $*TMPDIR, :$projects-file is copy, 
-    Bool :$notest, Bool :$force, Int :$jobs, Bool :$report, Bool :$v, Bool :$dry, 
+    Bool :$no-test, Bool :$force, Int :$jobs, Bool :$report, Bool :$v, Bool :$dry,
     Bool :$skip-depends, Bool :$skip-build-depends, Bool :$skip-test-depends,
     Bool :$shuffle, Bool :$no-wrap, Bool :$boring) is export(:install) {
 
@@ -160,7 +160,7 @@ multi MAIN('install', *@modules, :$lib, :$ignore, :$save-to = $*TMPDIR, :$projec
         :$save-to, :$projects-file,
         :$boring, :$jobs,
         :$skip-depends, :$skip-build-depends
-        :skip-test-depends(($notest || $skip-test-depends) ?? True !! False),
+        :skip-test-depends(($no-test || $skip-test-depends) ?? True !! False),
     );
 
 
@@ -215,7 +215,7 @@ multi MAIN('install', *@modules, :$lib, :$ignore, :$save-to = $*TMPDIR, :$projec
     die "!!!> Aborting. Build failures for: {@failed-builds.map(*.id)}" if !$report && !$force && @failed-builds.elems;
 
     # TESTING
-    unless $notest {
+    unless $no-test {
         # force the tests so we can report them. *then* we will bail out
         my $tested = &MAIN('test', @repos, :lib('blib/lib'), :$lib, 
             :$v, :$boring, :$jobs, :$shuffle, :force, :$no-wrap

--- a/lib/Zef/Authority.pm6
+++ b/lib/Zef/Authority.pm6
@@ -48,7 +48,7 @@ role Zef::Authority {
 
                 for $filters.list -> $f {
                     next unless $f.so;
-                    next FILTERS unless $f.isa(Str) || $f.isa(Int) || $f.isa(Num) || $f.isa(Rat);
+                    next FILTERS unless $f ~~ Str|Int|Num|Rat;
                     temp $ver;
 
                     if $field ~~ /^ver[sion]?/ {

--- a/lib/Zef/Manifest.pm6
+++ b/lib/Zef/Manifest.pm6
@@ -8,7 +8,7 @@ class Zef::Manifest {
     submethod BUILD(:$!cur, :$!basename = 'MANIFEST', Bool :$!create) {
         $!lock := Lock.new;
         $!cur   = CompUnitRepo::Local::Installation.new($!cur)\
-            unless $!cur.isa(CompUnitRepo::Local::Installation);
+            unless $!cur ~~ CompUnitRepo::Local::Installation;
 
         with $!cur.IO.child($!basename) -> $mani-path {
             if !$mani-path.IO.e || !$mani-path.IO.f {

--- a/lib/Zef/Manifest.pm6
+++ b/lib/Zef/Manifest.pm6
@@ -49,7 +49,7 @@ class Zef::Manifest {
     method file-count {
         # CURLI appears to have named this confusingly as it is really a max value of all file ids
         # and not an actual count of anything.
-        my $fc = [max] $.files(:bin, :provides).list;
+        my $fc = [max] $.files(:bin, :provides).flat.list;
         $fc > 0 ?? $fc !! 0; # max on empty array = -Inf
     }
 

--- a/lib/Zef/Net/HTTP/Dialer.pm6
+++ b/lib/Zef/Net/HTTP/Dialer.pm6
@@ -2,7 +2,7 @@ use Zef::Net::HTTP;
 try require IO::Socket::SSL;
 
 class Zef::Net::HTTP::Dialer does HTTP::Dialer {
-    has $.can-ssl = !::("IO::Socket::SSL").isa(Failure);
+    has $.can-ssl = !::("IO::Socket::SSL") ~~ Failure;
 
     method dial(HTTP::URI $uri) {
         my $scheme = $uri.scheme // 'http';

--- a/lib/Zef/Net/HTTP/Request.pm6
+++ b/lib/Zef/Net/HTTP/Request.pm6
@@ -40,7 +40,7 @@ class Zef::Net::HTTP::Request does HTTP::Request {
         $!uri := Zef::Net::URI.new(:$!url) or die "Couldn't create a URI from `$!url`";
 
         if ?$!proxy {
-            if ?$!proxy.isa(Str) {
+            if ?$!proxy ~~ Str {
                 $!proxy := Zef::Net::URI.new(url => $!proxy);
             }
             else {

--- a/lib/Zef/Process.pm6
+++ b/lib/Zef/Process.pm6
@@ -19,7 +19,7 @@ class Zef::Process {
     has $.finished;
 
     submethod BUILD(:$!command = $*EXECUTABLE, :@!args, :$!cwd = $*CWD, :%!env = %*ENV.hash, Bool :$!async, :$!id) {
-        $!can-async = $*DISTRO.name eq 'macosx' ?? False !! !::("Proc::Async").isa(Failure);
+        $!can-async = $*DISTRO.name eq 'macosx' ?? False !! !::("Proc::Async") ~~ Failure;
         $!stdout := Supply.new;
         $!stderr := Supply.new;
         $!type   := $!async && $!can-async ?? ::("Proc::Async") !! ::("Proc");

--- a/lib/Zef/Process.pm6
+++ b/lib/Zef/Process.pm6
@@ -31,13 +31,13 @@ class Zef::Process {
                     ?? $!command.IO.basename 
                     !! ''; # shameful
 
-        die "Proc::Async not available, but option :\$!async explicitily requested it (JVM and OSX NYI)"
+        die "Proc::Async not available, but option --jobs explicitily requested it (JVM and OSX NYI)"
             if $!async && !$!can-async;
     }
 
     method start {
         # error check is duplicated here because, dun dun dunnn, JVM won't die otherwise
-        die "Proc::Async not available, but option :\$!async explicitily requested it (JVM and OSX NYI)"
+        die "Proc::Async not available, but option --jobs explicitily requested it (JVM and OSX NYI)"
             if $!async && !$!can-async;
 
         if $!async {

--- a/lib/Zef/Process.pm6
+++ b/lib/Zef/Process.pm6
@@ -19,7 +19,7 @@ class Zef::Process {
     has $.finished;
 
     submethod BUILD(:$!command = $*EXECUTABLE, :@!args, :$!cwd = $*CWD, :%!env = %*ENV.hash, Bool :$!async, :$!id) {
-        $!can-async = $*DISTRO.name eq 'macosx' ?? False !! !::("Proc::Async") ~~ Failure;
+        $!can-async = $*DISTRO.name eq 'macosx' ?? False !! not ::("Proc::Async") ~~ Failure;
         $!stdout := Supply.new;
         $!stderr := Supply.new;
         $!type   := $!async && $!can-async ?? ::("Proc::Async") !! ::("Proc");

--- a/lib/Zef/Roles/Hooking.pm6
+++ b/lib/Zef/Roles/Hooking.pm6
@@ -34,7 +34,8 @@ role Zef::Roles::Hooking {
         my $legacy-code = $.path.child('Build.pm');
         my $hooks-dir   = $.path.child('hooks');
         my $cmd         = "Build.new.build('{$.path}');";
-        # last item has no affect on program execution, but allows STDMux to show `Build.pm` as the file name
-        $($*EXECUTABLE, '-I.', '-MBuild', '-e', $.async ?? $cmd !! '"'~$cmd~'"', 'Build.pm');
+        # Last item has no affect on program execution, but allows STDMux to show `Build.pm` as the file name.
+        # $.jobs implies Proc::Async, which requires different quoting here to work.
+        $($*EXECUTABLE, '-I.', '-MBuild', '-e', $.jobs ?? $cmd !! '"'~$cmd~'"', 'Build.pm');
     }
 }

--- a/lib/Zef/Utils/Git.pm6
+++ b/lib/Zef/Utils/Git.pm6
@@ -12,13 +12,15 @@ class Zef::Utils::Git {
                 :cwd($save-to.IO.dirname),
                 :!async,
             );
-            await $proc.start;
+            my $clone-promise = $proc.start;
+            $clone-promise.result; # osx bug RT125758
+            await $clone-promise;
             my $git_result = $proc.exitcode;
 
             given $git_result {
                 when 128 { # directory already exists and is not empty
                     if $branch {
-                        print "===> Attempting checkout `git checkout $branch {@!flags}`\n";
+                        print "===> Attempting to checkout via `git checkout $branch {@!flags}`\n";
                         $proc = Zef::Process.new(
                             :id("git checkout"),
                             :command('git'),
@@ -26,10 +28,12 @@ class Zef::Utils::Git {
                             :cwd($save-to.IO),
                             :!async,
                         );
-                        await $proc.start;
+                        my $checkout-promise = $proc.start;
+                        $checkout-promise.result; # osx bug RT125758
+                        await $checkout-promise;
                     }
 
-                    print "===> Attempting updating via `git pull`\n";
+                    print "===> Attempting to update via `git pull`\n";
                     $proc = Zef::Process.new(
                         :id("git pull"),
                         :command('git'), 
@@ -37,7 +41,9 @@ class Zef::Utils::Git {
                         :cwd($save-to.IO),
                         :!async,
                     );
-                    await $proc.start;
+                    my $pull-promise = $proc.start;
+                    $pull-promise.result; # osx bug RT125758
+                    await $pull-promise;
                     $git_result = $proc.exitcode;
                 }
             }


### PR DESCRIPTION
Set the number of processes/threads allowed to run at once.

Note that setting `--jobs` still implies the use of `Proc::Async`, and as such currently does not work on JVM or OSX.