### PR TITLE
Fix run/shell encoding error for non-utf8 output

### DIFF
--- a/lib/Zef/Utils/SystemInfo.pm6
+++ b/lib/Zef/Utils/SystemInfo.pm6
@@ -13,7 +13,7 @@ sub GET-TERM-COLUMNS is export {
     if $*DISTRO.is-win {
         # Windowsy
         my $default = 80 - 1;
-        my $r    = shell("mode", :out);
+        my $r    = shell("mode", :out, :enc('latin-1'));
         my $line = $r.out.lines.join("\n");
         return $default unless $line;
 
@@ -26,7 +26,7 @@ sub GET-TERM-COLUMNS is export {
     else {
         # Linuxy
         my $default = 120 - 1;
-        my $tput    = run("tput", "cols", :out);
+        my $tput    = run("tput", "cols", :out, :enc('latin-1'));
         if $tput.out.get ~~ /$<cols>=<.digit>+/ {
             my $cols = ~$/<cols>.comb(/\d/).join;
             return +$cols - 1 if try { +$cols }


### PR DESCRIPTION
cygx++ brings to attention in #65 that `Proc.run` and `Proc.shell` can cause encoding errors when reading from `.out`. A default encoding of `utf8` is normally applied, but since these instances are not shown to the user we will just use `latin-1` which will not error on invalid characters.

Other instances of `run` and `shell` will need a better solution, as their `.out` is output back to the terminal to be seen