### PR TITLE
fix resources/config.json for system installations

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -39,7 +39,7 @@
         "Zef::Utils::URI"        : "lib/Zef/Utils/URI.pm6"
     },
     "resources" : [
-        "resources/config.json"
+        "config.json"
     ],
     "auth"    : "github:ugexe",
     "authors" : [

--- a/lib/Zef/Config.pm6
+++ b/lib/Zef/Config.pm6
@@ -10,10 +10,10 @@ sub ZEF-CONFIG  is export {
 
 sub find-config {
     # use $*CWD
-    with "config.json"                      { return $_ if $_.IO.e }
+    with "config.json"            { return $_ if $_.IO.e }
     # use $*CWD/resources/config (such as during install)
-    with "resources/config.json"            { return $_ if $_.IO.e }
+    with "resources/config.json"  { return $_ if $_.IO.e }
     # use the config that was installed
-    with %?RESOURCES<resources/config.json> { return $_ if $_.IO.e }
+    with %?RESOURCES<config.json> { return $_ if $_.IO.e }
     die "Failed to find config file";
 }


### PR DESCRIPTION
Makes zef work on [Arch](https://aur.archlinux.org/packages/zef).