### PR TITLE
Supply based

### DIFF
--- a/lib/Zef.pm6
+++ b/lib/Zef.pm6
@@ -12,6 +12,10 @@ role Messenger  {
     has $.stderr = Supplier.new;
 }
 
+enum LEVEL is export <FATAL ERROR WARN INFO VERBOSE DEBUG TRACE>;
+enum STAGE is export <RESOLVE FETCH EXTRACT FILTER BUILD TEST INSTALL REPORT>;
+enum PHASE is export <BEFORE START LIVE STOP AFTER>;
+
 # Get a resource located at a uri and save it to the local disk
 role Fetcher {
     method fetch($uri, $save-as) { ... }

--- a/lib/Zef/CLI.pm6
+++ b/lib/Zef/CLI.pm6
@@ -26,13 +26,12 @@ package Zef::CLI {
 
     #| Download specific distributions
     multi MAIN('fetch', Bool :$force, Bool :v(:$verbose), *@identities ($, *@)) is export {
-        my $client     = Zef::Client.new(:$config, :$verbose, :$force);
+        my $client = get-client(:$config, :$verbose, :$force);
         my @candidates = |$client.find-candidates(|@identities>>.&str2identity);
         die "Failed to resolve any candidates. No reason to proceed" unless +@candidates;
         my @fetched    = |$client.fetch(|@candidates);
         my @fail       = |@candidates.grep: {.as !~~ any(@fetched>>.as)}
 
-        say "===> Fetched: {.as}{?$verbose??' at '~.dist.path!!''}" for @fetched;
         say "!!!> Fetch failed: {.as}{?$verbose??' at '~.dist.path!!''}" for @fail;
 
         exit +@fetched && +@fetched == +@candidates && +@fail == 0 ?? 0 !! 1;
@@ -40,13 +39,12 @@ package Zef::CLI {
 
     #| Run tests
     multi MAIN('test', Bool :$force, Bool :v(:$verbose), *@paths ($, *@)) is export {
-        my $client     = Zef::Client.new(:$config, :$verbose, :$force);
+        my $client     = get-client(:$config, :$verbose, :$force);
         my @candidates = |$client.link-candidates( @paths.map(*.&path2candidate) );
         die "Failed to resolve any candidates. No reason to proceed" unless +@candidates;
         my @tested = |$client.test(|@candidates);
         my (:@test-pass, :@test-fail) := @tested.classify: {.test-results.grep(*.so) ?? <test-pass> !! <test-fail> }
 
-        say "===> Testing passed: {.as}{?$verbose??' at '~.dist.path!!''}" for @test-pass;
         say "!!!> Testing failed: {.as}{?$verbose??' at '~.dist.path!!''}" for @test-fail;
 
         exit ?@test-fail ?? 1 !! ?@test-pass ?? 0 !! 255;
@@ -54,7 +52,7 @@ package Zef::CLI {
 
     #| Run Build.pm
     multi MAIN('build', Bool :$force, Bool :v(:$verbose), *@paths ($, *@)) is export {
-        my $client = Zef::Client.new(:$config, :$verbose, :$force);
+        my $client = get-client(:$config, :$verbose, :$force);
         my @candidates = |$client.link-candidates( @paths.map(*.&path2candidate) );
         die "Failed to resolve any candidates. No reason to proceed" unless +@candidates;
 
@@ -80,9 +78,8 @@ package Zef::CLI {
                 !! die("Don't understand identity: {$wanted}");
         }
 
-        my @excluded   = grep *.defined, ?$depsonly ?? (|@identities, |$exclude) !! $exclude;
-
-        my $client     = Zef::Client.new(:$config, :exclude(|@excluded), :$force, :$verbose, :$depends, :$test-depends, :$build-depends);
+        my @excluded = grep *.defined, ?$depsonly ?? (|@identities, |$exclude) !! $exclude;
+        my $client   = get-client(:$config, :exclude(|@excluded), :$force, :$verbose, :$depends, :$test-depends, :$build-depends);
 
         my (:@wanted-identities, :@skip-identities) := @identities\
             .classify: {$client.is-installed($_) ?? <skip-identities> !! <wanted-identities>}
@@ -90,12 +87,19 @@ package Zef::CLI {
             if $verbose && +@skip-identities;
 
         my @path-candidates = @paths.map(*.&path2candidate);
+        die "No candidates found matching: {@paths.join(', ')}" if +@paths && +@path-candidates == 0;
+
         my @url-candidates  = $client.fetch( |@urls.map({ Candidate.new(:as($_), :uri($_)) }) ) if +@urls;
+        die "No candidates found matching: {@url-candidates.join(', ')}" if +@urls && +@url-candidates == 0;
+
         my @requested-identities = (?$force ?? @identities !! @wanted-identities)\
             .grep: { $_ ~~ none(@url-candidates.map(*.dist.identity)) }
         my @requested  = |$client.find-candidates(:$upgrade, |@requested-identities) if +@requested-identities;
+        die "No candidates found matching: {@requested-identities.join(', ')}" if +@requested-identities && +@requested == 0;
+
         my @prereqs    = |$client.find-prereq-candidates(|@path-candidates, |@url-candidates, |@requested)\
             if +@path-candidates || +@url-candidates || +@requested;
+
         my @candidates = grep *.defined, |@path-candidates, |@url-candidates, |@requested, |@prereqs;
         die "All candidates are currently installed. No reason to proceed (use --force to continue anyway)"\
             unless +@candidates || ?$force;
@@ -107,14 +111,13 @@ package Zef::CLI {
         my @installed  = |$client.install( :@to, :$test, :$upgrade, :$update, :$dry, |@fetched );
         my @fail       = |@candidates.grep: {.as !~~ any(@installed>>.as)}
 
-        say "===> Installed: {@installed.map(*.dist.identity).join(', ')}"   if +@installed;
         say "!!!> Install failures: {@fail.map(*.dist.identity).join(', ')}" if +@fail;
         exit +@installed && +@installed == +@candidates && +@fail == 0 ?? 0 !! 1;
     }
 
     #| Uninstall
     multi MAIN('uninstall', Bool :v(:$verbose), Bool :$force, :from(:$uninstall-from) = ['site'], *@identities ($, *@)) is export {
-        my $client = Zef::Client.new(:$config, :$force, :$verbose);
+        my $client = get-client(:$config, :$verbose, :$force);
         my CompUnit::Repository @from = $uninstall-from.map(*.&str2cur);
         die "`uninstall` command currently requires a bleeding edge version of rakudo" unless any(@from>>.can('uninstall'));
 
@@ -129,7 +132,7 @@ package Zef::CLI {
 
     #| Get a list of possible distribution candidates for the given terms
     multi MAIN('search', Int :$wrap = False, Bool :v(:$verbose), *@terms ($, *@)) is export {
-        my $client  = Zef::Client.new(:$config, :$verbose);
+        my $client = get-client(:$config, :$verbose);
         my @results = $client.search(|@terms);
 
         say "===> Found " ~ +@results ~ " results";
@@ -145,7 +148,7 @@ package Zef::CLI {
 
     #| A list of available modules from enabled content storages
     multi MAIN('list', Int :$max?, Bool :v(:$verbose), Bool :i(:$installed), *@at) is export {
-        my $client = Zef::Client.new(:$config, :$verbose);
+        my $client = get-client(:$config, :$verbose);
 
         my $found := ?$installed
             ?? $client.list-installed(|@at.map(*.&str2cur))
@@ -166,14 +169,14 @@ package Zef::CLI {
 
     #| View reverse dependencies of a distribution
     multi MAIN('rdepends', $identity, Bool :v(:$verbose)) {
-        my $client = Zef::Client.new(:$config, :$verbose);
+        my $client = get-client(:$config, :$verbose);
         .dist.identity.say for $client.list-rev-depends($identity);
         exit 0;
     }
 
     #| Detailed distribution information
     multi MAIN('info', $identity, Int :$wrap = False, Bool :v(:$verbose)) is export {
-        my $client = Zef::Client.new(:$config, :$verbose);
+        my $client = get-client(:$config, :$verbose);
         my $candi  = $client.search($identity, :max-results(1))[0]\
             or die "Found no candidates matching identity: {$identity}";
         my $dist  := $candi.dist;
@@ -212,7 +215,7 @@ package Zef::CLI {
 
     #| Download a single module and change into its directory
     multi MAIN('look', $identity, Bool :$force, Bool :v(:$verbose)) is export {
-        my $client     = Zef::Client.new(:$config, :$verbose, :$force);
+        my $client     = get-client(:$config, :$verbose, :$force);
         my @candidates = |$client.find-candidates( str2identity($identity) );
         die "Failed to resolve any candidates. No reason to proceed" unless +@candidates;
         my (:@remote, :@local) := @candidates.classify: {.dist !~~ Zef::Distribution::Local ?? <remote> !! <local>}
@@ -224,7 +227,7 @@ package Zef::CLI {
 
     #| Smoke test
     multi MAIN('smoke', Bool :v(:$verbose), Bool :$force, Bool :$test = True,Bool :$fetch = True, :$exclude, :to(:$install-to) = ['site']) is export {
-        my $client                  = Zef::Client.new(:$config, :$force, :$verbose);
+        my $client                  = get-client(:$config, :$verbose, :$force);
         my @identities              = $client.available.values.flatmap(*.keys).unique;
         my CompUnit::Repository @to = $install-to.map(*.&str2cur);
         say "===> Smoke testing with {+@identities} distributions...";
@@ -244,7 +247,7 @@ package Zef::CLI {
 
     #| Update package indexes
     multi MAIN('update', Bool :v(:$verbose), *@names) is export {
-        my $client  = Zef::Client.new(:$config);
+        my $client  = get-client(:$config);
         my %results = $client.storage.update(|@names);
         my $rows    = |%results.map: {[.key, .value]};
         die "An unknown plugin name used" if +@names && (+@names > +$rows);
@@ -335,6 +338,20 @@ package Zef::CLI {
                 --/<short-name> # `--/cpan` Disable plugin with short-name `cpan`
 
             END_USAGE
+    }
+
+    sub get-client(*%_) {
+        my $client = Zef::Client.new(|%_);
+        my $logger = $client.logger;
+        my $log    = $logger.Supply.grep({ .<level> <= (?%_<verbose> ?? VERBOSE !! INFO) });
+        $log.tap: -> $m {
+            given $m.<phase> {
+                when BEFORE { say "===> {$m.<message>}" }
+                when AFTER  { say "===> {$m.<message>}" }
+                default     { say $m.<message> }
+            }
+        }
+        $client;
     }
 
     # maybe its a name, maybe its a spec/path. either way  Zef::App methods take a CURs, not strings

--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -13,8 +13,9 @@ class Zef::Client {
     has $.storage;
     has $.extractor;
     has $.tester;
-
     has $.config;
+
+    has $.logger = Supplier.new;
 
     has @.exclude;
     has @!ignore = <Test NativeCall lib MONKEY-TYPING nqp>;
@@ -59,40 +60,84 @@ class Zef::Client {
     }
 
     method find-candidates(Bool :$upgrade, *@identities ($, *@)) {
-        my $candidates := unique :as(*.dist.identity), $!storage.candidates(|@identities, :$upgrade);
+        self.logger.emit({
+            level   => INFO,
+            stage   => RESOLVE,
+            phase   => BEFORE,
+            payload => @identities,
+            message => "Searching for: {@identities.join(', ')}",
+        });
+        my @candidates = self!find-candidates(:$upgrade, |@identities);
+        self.logger.emit({
+            level   => VERBOSE,
+            stage   => RESOLVE,
+            phase   => AFTER,
+            payload => @candidates.map(*.dist.identity),
+            message => "Found: {@candidates.map(*.dist.identity).join(', ')}",
+        });
+        @candidates;
+
+    }
+    method !find-candidates(Bool :$upgrade, *@identities ($, *@)) {
+        my $candidates := $!storage.candidates(|@identities, :$upgrade).unique(:as(*.dist.identity));
     }
 
     method find-prereq-candidates(Bool :$upgrade, *@candis ($, *@)) {
-        my @skip  = @candis.map(*.dist.identity);
-        my @specs = |self.list-dependencies(@candis);
+        my @skip = @candis.map(*.dist);
+        my sub filter-needed(*@specs) {
+            @specs.grep(-> $spec { !@skip.first(-> $dist {?$dist.contains-spec($spec)}) }).grep({ not self.is-installed($_) });
+        }
 
-        my $prereqs := unique :as(*.dist.identity), gather {
+        my @prereqs = unique :as(*.dist.identity), gather {
+            my @specs = |self.list-dependencies(@candis);
+
             while @specs.splice -> @specs-batch {
-                next unless my @needed = @specs-batch\
-                    .grep({.identity ~~ none(@skip)})\
-                    .grep({not self.is-installed($_)})\
-                    .map(*.identity);
-                next unless my @prereq-candidates = |self.find-candidates(:$upgrade, |@needed);
+                self.logger.emit({
+                    level   => DEBUG,
+                    stage   => RESOLVE,
+                    phase   => BEFORE,
+                    payload => @specs-batch,
+                    message => "Dependencies: {@specs-batch.unique.join(', ')}",
+                });
 
-                my @prereq-identities = @prereq-candidates.map(*.dist.identity);
-                @skip.append(|@prereq-identities);
+                next unless my @needed = filter-needed(@specs-batch);
+                self.logger.emit({
+                    level   => INFO,
+                    stage   => RESOLVE,
+                    phase   => BEFORE,
+                    payload => @needed,
+                    message => "Searching for missing dependencies: {@needed.map(*.identity).join(', ')}",
+                });
+
+                next unless my @prereq-candidates = |self!find-candidates(:$upgrade, |@needed.map(*.identity));
+                self.logger.emit({
+                    level   => VERBOSE,
+                    stage   => RESOLVE,
+                    phase   => AFTER,
+                    payload => @prereq-candidates,
+                    message => "Found dependencies: {@prereq-candidates.map(*.dist.identity)}",
+                });
+
+                @skip.append: |@prereq-candidates.map(*.dist);
                 @specs = |self.list-dependencies(@prereq-candidates);
-                take @prereq-candidates.grep({.is-dependency = True}).Slip;
+                for @prereq-candidates -> $prereq {
+                    $prereq.is-dependency = True;
+                    take $prereq;
+                }
             }
         }
     }
 
     method fetch(*@candidates ($, *@)) {
-        my $stdout = Supplier.new;
-        my &out = ?$!verbose ?? -> $o {$o.say} !! -> $ { };
-        $stdout.Supply.tap(&out);
-
-        my $stderr = Supplier.new;
-        my &err = ?$!verbose ?? -> $e {$e.say} !! -> $ { };
-        $stderr.Supply.tap(&err);
-
-        say "===> Fetching: {@candidates.map(*.as).join(', ')}";
         my @saved = eager gather for @candidates -> $candi {
+            self.logger.emit({
+                level   => INFO,
+                stage   => FETCH,
+                phase   => BEFORE,
+                payload => $candi,
+                message => "Fetching: {$candi.as}",
+            });
+
             my $from     = $candi.from;
             my $as       = $candi.as;
             my $uri      = $candi.uri;
@@ -105,19 +150,33 @@ class Zef::Client {
             # It could be a file or url; $dist.source-url contains where the source was
             # originally located but we may want to use a local copy (while retaining
             # the original source-url for some other purpose like updating)
-
-            say "{?$from??qq|[$from] |!!''}{$uri} staging at: $stage-at" if ?$!verbose;
-
-            my $save-to    = $!fetcher.fetch($uri, $stage-at, :$stdout, :$stderr);
+            my $save-to    = $!fetcher.fetch($uri, $stage-at, :$!logger);
             my $relpath    = $stage-at.relative($tmp);
             my $extract-to = $!cache.IO.child($relpath);
-
-            say "$uri saved to $save-to" if ?$!verbose;
+            self.logger.emit({
+                level   => VERBOSE,
+                stage   => FETCH,
+                phase   => AFTER,
+                payload => $candi,
+                message => "Fetched: {$candi.as} to $save-to",
+            });
 
             # should probably break this out into its out method
-            say "[{$!extractor.^name}] Extracting: {$save-to} to {$extract-to}" if ?$!verbose;
-            my $dist-dir = $!extractor.extract($save-to, $extract-to);
-            say "Extracted to: {$dist-dir}" if ?$!verbose;
+            self.logger.emit({
+                level   => DEBUG,
+                stage   => EXTRACT,
+                phase   => BEFORE,
+                payload => $candi,
+                message => "Extracting: {$candi.as}",
+            });
+            my $dist-dir = $!extractor.extract($save-to, $extract-to, :$!logger);
+            self.logger.emit({
+                level   => DEBUG,
+                stage   => EXTRACT,
+                phase   => AFTER,
+                payload => $candi,
+                message => "Extracted: {$candi.as} to {$dist-dir}",
+            });
 
             # $candi.dist may already contain a distribution object, but we reassign it as a
             # Zef::Distribution::Local so that it has .path/.IO methods. These could be
@@ -127,13 +186,8 @@ class Zef::Client {
             my $local-candi = $candi.clone(:$dist);
             # XXX: the above used to just be `$candi.dist = $dist` where dist is rw
 
-            say "{$local-candi.dist.identity} fulfills the request for {$local-candi.as}" if $!verbose;
-
             take $local-candi;
         }
-
-        $stdout.done;
-        $stderr.done;
 
         # Calls optional `.store` method on all ContentStorage plugins so they may
         # choose to cache the dist or simply cache the meta data of what is installed.
@@ -147,60 +201,93 @@ class Zef::Client {
     method build(*@candidates ($, *@)) {
         my @built = eager gather for @candidates -> $candi {
             my $dist := $candi.dist;
-            take !$dist.IO.child('Build.pm').e
-                ?? $candi
-                !! do {
-                    my $result = legacy-hook($candi);
+            unless ?$dist.IO.child('Build.pm').e {
+                self.logger.emit({
+                    level   => DEBUG,
+                    stage   => BUILD,
+                    phase   => BEFORE,
+                    payload => $candi,
+                    message => "# SKIP: No Build.pm for {$candi.dist.?identity // $candi.as}",
+                });
+                take $candi;
+                next();
+            }
 
-                    if !$result {
-                        die "Aborting due to build failure: {$candi.dist.?identity // $candi.uri}"
-                        ~   "(use --force to override)" unless ?$!force;
-                        say "build failure: {$candi.dist.?identity // $candi.uri}. "
-                        ~   "Continuing anyway with --force"
-                    }
-                    else {
-                        say "Build passed for {$candi.dist.?identity // $candi.uri}";
-                    }
+            $!logger.emit({
+                level   => INFO,
+                stage   => BUILD,
+                phase   => BEFORE,
+                payload => $candi,
+                message => "Building: {$candi.dist.?identity // $candi.as}",
+            });
 
-                    $candi does role :: { has $.build-results = ?$result };
-                }
+            my $result = legacy-hook($candi, :$!logger);
+
+            $candi does role :: { has $.build-results = ?$result };
+
+            if !$result {
+                self.logger.emit({
+                    level   => ERROR,
+                    stage   => BUILD,
+                    phase   => AFTER,
+                    payload => $candi,
+                    message => "Building [FAIL]: {$candi.dist.?identity // $candi.as}",
+                });
+                die "Aborting due to build failure: {$candi.dist.?identity // $candi.uri}"
+                ~   "(use --force to override)" unless ?$!force;
+            }
+            else {
+                self.logger.emit({
+                    level   => INFO,
+                    stage   => BUILD,
+                    phase   => AFTER,
+                    payload => $candi,
+                    message => "Building [OK] for {$candi.dist.?identity // $candi.as}",
+                });
+            }
+
+            take $candi;
         }
     }
 
     # xxx: needs some love
     method test(:@includes, *@candidates ($, *@)) {
-        my $stdout = Supplier.new;
-        my &out = ?$!verbose ?? -> $o {$o.say} !! -> $ { };
-        $stdout.Supply.tap(&out);
-
-        my $stderr = Supplier.new;
-        my &err = ?$!verbose ?? -> $e {$e.say} !! -> $ { };
-        $stderr.Supply.tap(&err);
-
         my @tested = eager gather for @candidates -> $candi {
-            say "Start test phase for: {$candi.dist.?identity // $candi.uri}";
+            self.logger.emit({
+                level   => INFO,
+                stage   => TEST,
+                phase   => BEFORE,
+                payload => $candi,
+                message => "Testing: {$candi.dist.?identity // $candi.as}",
+            });
 
-            my @result = $!tester.test($candi.dist.path, :includes($candi.dist.metainfo<includes> // []), :$stdout, :$stderr);
+            my @result = $!tester.test($candi.dist.path, :includes($candi.dist.metainfo<includes> // []), :$!logger);
+
+            $candi does role :: { has $.test-results = |@result };
 
             if @result.grep(*.not).elems {
-                die "Aborting due to test failure: {$candi.dist.?identity // $candi.uri} "
+                self.logger.emit({
+                    level   => ERROR,
+                    stage   => TEST,
+                    phase   => AFTER,
+                    payload => $candi,
+                    message => "Testing [FAIL]: {$candi.dist.?identity // $candi.as}",
+                });
+                die "Aborting due to test failure: {$candi.dist.?identity // $candi.as} "
                 ~   "(use --force to override)" unless ?$!force;
-                say "Test failure: {$candi.dist.?identity // $candi.uri}. "
-                ~   "Continuing anyway with --force"
             }
             else {
-                say "Testing passed for {$candi.dist.?identity // $candi.uri}";
+                self.logger.emit({
+                    level   => INFO,
+                    stage   => TEST,
+                    phase   => AFTER,
+                    payload => $candi,
+                    message => "Testing [OK] for {$candi.dist.?identity // $candi.as}",
+                });
             }
-
-            # This method of attaching meta information will eventually be replaced
-            # with a `Plan`/`Result` class, but its great for fleshing out a design now
-            $candi does role :: { has $.test-results = |@result };
 
             take $candi;
         }
-
-        $stdout.done;
-        $stderr.done;
 
         @tested
     }
@@ -221,12 +308,28 @@ class Zef::Client {
         *@candidates ($, *@),
         *%_
         ) {
-        my &notice = ?$!force ?? &say !! &die;
-        my (@curs, @cant-install);
-        @to.map: { my $group := $_.?can-install ?? @curs !! @cant-install; $group.push($_) }
-        say "You specified the following CompUnit::Repository install targets that don't appear writeable/installable:\n"
-            ~ "\t{@cant-install.join(', ')}" if +@cant-install;
-        die "Need a valid installation target to continue" unless ?$dry || (+@curs - +@cant-install) > 0;
+        my @curs = @to.grep: -> $cur {
+            UNDO {
+                self.logger.emit({
+                    level   => WARN,
+                    stage   => INSTALL,
+                    phase   => BEFORE,
+                    payload => $cur,
+                    message => "CompUnit::Repository install target is not writeable/installable: {$cur}"
+                });
+            }
+            KEEP {
+                self.logger.emit({
+                    level   => TRACE,
+                    stage   => INSTALL,
+                    phase   => BEFORE,
+                    payload => $cur,
+                    message => "CompUnit::Repository install target is valid: {$cur}"
+                });
+            }
+            $cur.?can-install || next();
+        }
+        die "Need a valid installation target to continue" unless ?$dry || +@curs;
 
         # XXX: Each loop block below essentially represents a phase, so they will probably
         # be moved into their own method/module related directly to their phase. For now
@@ -247,23 +350,44 @@ class Zef::Client {
         # problem outlined below under `Sort Phase` (a depends on [A, B] where A gets filtered out
         # below because it has the wrong license means we don't need anything that depends on A but
         # *do* need to replace those items with things depended on by B [which replaces A])
-        say "===> Filtering: {@fetched-candidates.map(*.dist.identity).join(', ')}";
         my @filtered-candidates = eager gather for @fetched-candidates -> $candi {
             my $dist := $candi.dist;
+            self.logger.emit({
+                level   => DEBUG,
+                stage   => FILTER,
+                phase   => BEFORE,
+                payload => $candi,
+                message => "Filtering: {$dist.identity}",
+            });
+
             # todo: Change config.json to `"Filter" : { "License" : "xxx" }`)
-            given $!config<License> {
+            my $msg = do given $!config<License> {
                 CATCH { default {
-                    say $_.message;
-                    die "Allowed licenses: {$!config<License>.<whitelist>.join(',')    || 'n/a'}\n"
+                    die "{$_.message}\n"
+                    ~   "Allowed licenses: {$!config<License>.<whitelist>.join(',')    || 'n/a'}\n"
                     ~   "Disallowed licenses: {$!config<License>.<blacklist>.join(',') || 'n/a'}";
                 } }
                 when .<blacklist>.?chars && any(|.<blacklist>) ~~ any('*', $dist.license // '') {
-                    notice "License blacklist configuration exists and matches {$dist.license // 'n/a'} for {$dist.name}";
+                    $ = "License blacklist configuration exists and matches {$dist.license // 'n/a'} for {$dist.name}";
                 }
                 when .<whitelist>.?chars && any(|.<whitelist>) ~~ none('*', $dist.license // '') {
-                    notice "License whitelist configuration exists and does not match {$dist.license // 'n/a'} for {$dist.name}";
+                    $ = "License whitelist configuration exists and does not match {$dist.license // 'n/a'} for {$dist.name}";
                 }
             }
+
+            ?$msg ?? $!logger.emit({
+                level   => ERROR,
+                stage   => FILTER,
+                phase   => AFTER,
+                payload => $candi,
+                message => "Filtering [FAIL] for {$candi.dist.?identity // $candi.as}: $msg",
+            }) !! $!logger.emit({
+                level   => DEBUG,
+                stage   => FILTER,
+                phase   => AFTER,
+                payload => $candi,
+                message => "Filtering [OK] for {$candi.dist.?identity // $candi.as}",
+            });
 
             take $candi;
         }
@@ -308,26 +432,56 @@ class Zef::Client {
         # Install Phase:
         # Ideally `--dry` uses a special unique CompUnit::Repository that is meant to be deleted entirely
         # and contain only the modules needed for this specific run/plan
-        say "===> Installing: {@tested-candidates.map(*.dist.identity).join(', ')}";
         my @installed-candidates = eager gather for @tested-candidates -> $candi {
+            self.logger.emit({
+                level   => INFO,
+                stage   => INSTALL,
+                phase   => BEFORE,
+                payload => $candi,
+                message => "Installing: {$candi.dist.?identity // $candi.as}",
+            });
+
             my @installed-at = |@curs.grep: -> $cur {
                 # CURI.install is bugged; $dist.provides/files will both get modified and fuck up
                 # any subsequent .install as the fuck up involves changing the data structures
                 my $dist = $candi.dist.clone(provides => $candi.dist.provides, files => $candi.dist.files);
 
                 if ?$dry {
-                    say "{$dist.identity}{$!verbose??q|#|~$dist.path!!''} processed successfully" if $!verbose;
+                    self.logger.emit({
+                        level   => VERBOSE,
+                        stage   => INSTALL,
+                        phase   => AFTER,
+                        payload => $candi,
+                        message => "(dry) Installed: {$candi.dist.?identity // $candi.as}",
+                    });
                 }
                 else {
                     #$!lock.protect({
                     try {
-                        CATCH { default {.rethrow} }
-                        say "Installing {$dist.identity} to $cur" if $!verbose;
-                        $ = $cur.install($dist, $dist.sources(:absolute), $dist.scripts, $dist.resources, :$!force);
+                        CATCH { default {
+                            self.logger.emit({
+                                level   => ERROR,
+                                stage   => INSTALL,
+                                phase   => AFTER,
+                                payload => $candi,
+                                message => "Install failure for {$candi.dist.?identity // $candi.as}: {$_}",
+                            });
+                            $_.rethrow;
+                        } }
+                        my $install = $cur.install($dist, $dist.sources(:absolute), $dist.scripts, $dist.resources, :$!force);
+                        self.logger.emit({
+                            level   => VERBOSE,
+                            stage   => INSTALL,
+                            phase   => AFTER,
+                            payload => $candi,
+                            message => "Install success: {$candi.dist.?identity // $candi.as}",
+                        }) if ?$install;
+                        $ = ?$install;
                     }
                     #});
                 }
             }
+
             take $candi if +@installed-at;
         }
 
@@ -337,8 +491,14 @@ class Zef::Client {
         # Optionally report to any cpan testers type service (testers.perl6.org)
         unless $dry {
             if @installed-candidates.map(*.dist).flatmap(*.scripts.keys).unique -> @bins {
-                say "\n{+@bins} bin/ script{+@bins>1??'s'!!''}{+@bins&&?$!verbose??' ['~@bins~']'!!''} installed to:"
-                ~   "\n" ~ @curs.map(*.prefix.child('bin')).join("\n");
+                my $msg = "\n{+@bins} bin/ script{+@bins>1??'s'!!''}{+@bins&&?$!verbose??' ['~@bins~']'!!''} installed to:"
+                ~ "\n" ~ @curs.map(*.prefix.child('bin')).join("\n");
+                self.logger.emit({
+                    level   => INFO,
+                    stage   => REPORT,
+                    phase   => LIVE,
+                    message => $msg,
+                });
             }
         }
 
@@ -508,13 +668,12 @@ class Zef::Client {
 
 # todo: write a real hooking implementation to CU::R::I instead of the current practice
 # of writing an installer specific (literally) Build.pm
-sub legacy-hook($candi) {
+sub legacy-hook($candi, :$logger) {
     my $dist := $candi.dist;
     my $DEBUG = ?%*ENV<ZEF_BUILDPM_DEBUG>;
 
     my $builder-path = $dist.IO.child('Build.pm');
     my $legacy-code  = $builder-path.IO.slurp;
-    say "[Build] Attempting to build via {$builder-path}" if ?$DEBUG;
 
     # if panda is declared as a dependency then there is no need to fix the code, although
     # it would still be wise for the author to change their code as outlined in $legacy-fixer-code
@@ -523,7 +682,13 @@ sub legacy-hook($candi) {
         && !$dist.build-depends\.first(/'panda' | 'Panda::'/)
         && !$dist.test-depends\ .first(/'panda' | 'Panda::'/) {
 
-        say "[Build] `build-depends` is missing entries. Attemping to mimick missing dependencies..." if ?$DEBUG;
+        $logger.emit({
+            level   => WARN,
+            stage   => BUILD,
+            phase   => LIVE,
+            payload => $candi,
+            message => "`build-depends` is missing entries. Attemping to mimick missing dependencies...",
+        });
 
         my $legacy-fixer-code = q:to/END_LEGACY_FIX/;
             class Build {
@@ -541,28 +706,48 @@ sub legacy-hook($candi) {
 
 
     my $cmd = "require <{$builder-path.basename}>; ::('Build').new.build('{$dist.IO.absolute}'); exit(0);";
-    say "[Build] Command: `$cmd`" if ?$DEBUG;
 
     my $result;
     try {
         use Zef::Shell;
-        CATCH { default { say "[Build] Something went wrong: $_" if ?$DEBUG; $result = False; } }
+        CATCH { default { $result = False; } }
         my @includes = $dist.metainfo<includes>.grep(*.defined).map: { "-I{$_}" }
         my @exec = |($*EXECUTABLE, '-Ilib/.precomp', '-I.', '-Ilib', |@includes, '-e', "$cmd");
-        say "[Build] cwd: {$dist.IO.absolute}" if ?$DEBUG;
-        say "[Build] exec: {@exec.join(' ')}"  if ?$DEBUG;
+
+        $logger.emit({
+            level   => DEBUG,
+            stage   => BUILD,
+            phase   => LIVE,
+            payload => $candi,
+            message => "Command: {@exec.join(' ')}",
+        });
+
         my $proc = zrun(|@exec, :cwd($dist.path), :out, :err);
         my @err = $proc.err.lines;
         my @out = $proc.out.lines;
-        if ?$DEBUG {
-            say "[Build] > $_" for @out;
-            say "[Build] ! $_" for @err;
-        }
+
         $ = $proc.out.close unless +@err;
         $ = $proc.err.close;
         $result = ?$proc;
+
+        $logger.emit({
+            level   => DEBUG,
+            stage   => BUILD,
+            phase   => LIVE,
+            payload => $candi,
+            message => @out.join("\n"),
+        }) if +@out;
+
+        $logger.emit({
+            level   => ERROR,
+            stage   => BUILD,
+            phase   => LIVE,
+            payload => $candi,
+            message => @err.join("\n"),
+        }) if +@err;
     }
+
     $builder-path.IO.unlink if $builder-path.ends-with('.zef') && "{$builder-path}".IO.e;
-    say "[Build] Result: {?$result??'Success'!!'Failure'}" if ?$DEBUG;
-    $ = $result;
+
+    $ = ?$result;
 }

--- a/lib/Zef/ContentStorage/P6C.pm6
+++ b/lib/Zef/ContentStorage/P6C.pm6
@@ -12,9 +12,7 @@ class Zef::ContentStorage::P6C does ContentStorage {
 
     method !gather-dists {
         once { self.update } if $.auto-update || !self!package-list-file.e;
-        return @!dists if +@!dists;
-
-        @!dists = gather for self!slurp-package-list -> $meta {
+        @!dists = cache gather for self!slurp-package-list -> $meta {
             my $dist = Zef::Distribution.new(|%($meta));
             take $dist;
         }

--- a/lib/Zef/Distribution/DependencySpecification.pm6
+++ b/lib/Zef/Distribution/DependencySpecification.pm6
@@ -17,11 +17,11 @@ class Zef::Distribution::DependencySpecification {
 
     method name            { $ = self.spec-parts<name> }
 
-    method version-matcher { $ = self.spec-parts<ver>  // '' }
+    method version-matcher { $ = self.spec-parts<ver>  // '*' }
 
-    method auth-matcher    { $ = self.spec-parts<auth> // '' }
+    method auth-matcher    { $ = self.spec-parts<auth> // ''  }
 
-    method api-matcher     { $ = self.spec-parts<api>  // '' }
+    method api-matcher     { $ = self.spec-parts<api>  // '*' }
 
     method !spec { $.spec || self.Str }
 

--- a/lib/Zef/Extract.pm6
+++ b/lib/Zef/Extract.pm6
@@ -1,18 +1,23 @@
 use Zef;
 
 class Zef::Extract does Pluggable {
-    method extract($path, $extract-to, Supplier :$stdout, Supplier :$stderr) {
+    method extract($path, $extract-to, Supplier :$logger) {
         die "Can't extract non-existent path: {$path}" unless $path.IO.e;
         die "Can't extract to non-existent path: {$extract-to}" unless $extract-to.IO.e || $extract-to.IO.mkdir;
         my $extractors := self.plugins.grep(*.extract-matcher($path)).cache;
         die "No extracting backend available" unless ?$extractors;
 
-        my $got = first *.IO.e, gather for $extractors -> $ex {
-            $ex.stdout.Supply.act: -> $out { ?$stdout ?? $stdout.emit($out) !! $*OUT.say($out) }
-            $ex.stderr.Supply.act: -> $err { ?$stderr ?? $stderr.emit($err) !! $*ERR.say($err) }
-            my $out = try $ex.extract($path, $extract-to);
-            $ex.stdout.done;
-            $ex.stderr.done;
+        my $got = first *.IO.e, gather for $extractors -> $extractor {
+            if ?$logger {
+                $logger.emit({ level => DEBUG, stage => EXTRACT, phase => START, payload => self, message => "Extracting with plugin: {$extractor.^name}" });
+                $extractor.stdout.Supply.act: -> $out { $logger.emit({ level => VERBOSE, stage => EXTRACT, phase => LIVE, message => $out }) }
+                $extractor.stderr.Supply.act: -> $err { $logger.emit({ level => ERROR,   stage => EXTRACT, phase => LIVE, message => $err }) }
+            }
+
+            my $out = try $extractor.extract($path, $extract-to);
+
+            $extractor.stdout.done;
+            $extractor.stderr.done;
             take $out;
         }
 

--- a/lib/Zef/Fetch.pm6
+++ b/lib/Zef/Fetch.pm6
@@ -4,13 +4,16 @@ use Zef::Utils::URI;
 class Zef::Fetch does Pluggable {
     method ACCEPTS($uri) { $ = $uri ~~ @$.plugins }
 
-    method fetch($uri, $save-as, Supplier :$stdout, Supplier :$stderr) {
+    method fetch($uri, $save-as, Supplier :$logger) {
         my $fetcher = self.plugins.first(*.fetch-matcher($uri));
 
         die "No fetching backend available" unless ?$fetcher;
 
-        $fetcher.stdout.Supply.act: -> $out { ?$stdout ?? $stdout.emit($out) !! $*OUT.say($out) }
-        $fetcher.stderr.Supply.act: -> $err { ?$stderr ?? $stderr.emit($err) !! $*ERR.say($err) }
+        if ?$logger {
+            $logger.emit({ level => DEBUG, stage => FETCH, phase => START, payload => self, message => "Fetching with plugin: {$fetcher.^name}" });
+            $fetcher.stdout.Supply.act: -> $out { $logger.emit({ level => VERBOSE, stage => FETCH, phase => LIVE, message => $out }) }
+            $fetcher.stderr.Supply.act: -> $err { $logger.emit({ level => ERROR,   stage => FETCH, phase => LIVE, message => $err }) }
+        }
 
         my $got = $fetcher.fetch($uri, $save-as);
 

--- a/lib/Zef/Shell/Test.pm6
+++ b/lib/Zef/Shell/Test.pm6
@@ -16,7 +16,6 @@ class Zef::Shell::Test is Zef::Shell does Tester does Messenger {
             # many tests are written with the assumption that $*CWD will be their distro's base directory
             # so we have to hack around it so people can still (rightfully) pass absolute paths to `.test`
             my $relpath   = $test-file.relative($path);
-            $.stdout.emit("[Zef::Shell::Test] Testing: {$relpath}");
 
             my $env = %*ENV;
             my @cur-p6lib  = $env<PERL6LIB>.?chars ?? $env<PERL6LIB>.split($*DISTRO.cur-sep) !! ();

--- a/lib/Zef/Shell/prove.pm6
+++ b/lib/Zef/Shell/prove.pm6
@@ -30,7 +30,6 @@ class Zef::Shell::prove is Zef::Shell does Tester does Messenger {
         die "path does not exist: {$path}" unless $path.IO.e;
         my $test-path = $path.IO.child('t');
         return True unless $test-path.e;
-        $.stdout.emit("[Zef::Shell::prove] Testing: {$test-path.absolute}");
 
         my $env = %*ENV;
         my @cur-p6lib  = $env<PERL6LIB>.?chars ?? $env<PERL6LIB>.split($*DISTRO.cur-sep) !! ();
@@ -40,7 +39,7 @@ class Zef::Shell::prove is Zef::Shell does Tester does Messenger {
         # XXX: -Ilib/.precomp is a workaround for rakudo precomp locking bug
         # It generates it .precomp in lib/.precomp/.precomp so the default
         # precomp folder being in use/locked won't affect our custom prefix copy
-        my $proc = zrun('prove', '-v', '-r', '-e', qq|$*EXECUTABLE -Ilib/.precomp|,
+        my $proc = zrun('prove', '-r', '-e', qq|$*EXECUTABLE -Ilib/.precomp|,
             $test-path.relative($path), :cwd($path), :$env, :out, :err);
 
         $.stdout.emit($_) for $proc.out.lines;

--- a/lib/Zef/Shell/prove6.pm6
+++ b/lib/Zef/Shell/prove6.pm6
@@ -19,7 +19,6 @@ class Zef::Shell::prove6 is Zef::Shell does Tester does Messenger {
         die "path does not exist: {$path}" unless $path.IO.e;
         my $test-path = $path.IO.child('t');
         return True unless $test-path.e;
-        $.stdout.emit("[Zef::Shell::prove6] Testing: {$test-path.absolute}");
 
         my $env = %*ENV;
         my @cur-p6lib  = $env<PERL6LIB>.?chars ?? $env<PERL6LIB>.split($*DISTRO.cur-sep) !! ();
@@ -29,7 +28,7 @@ class Zef::Shell::prove6 is Zef::Shell does Tester does Messenger {
         # XXX: -Ilib/.precomp is a workaround for rakudo precomp locking bug
         # It generates it .precomp in lib/.precomp/.precomp so the default
         # precomp folder being in use/locked won't affect our custom prefix copy
-        my $proc = zrun('prove6', '-Ilib/.precomp', '-v', '-r',
+        my $proc = zrun('prove6', '-Ilib/.precomp', '-r',
             $test-path.relative($path), :cwd($path), :$env, :out, :err);
 
         $.stdout.emit($_) for $proc.out.lines;

--- a/lib/Zef/Test.pm6
+++ b/lib/Zef/Test.pm6
@@ -1,13 +1,16 @@
 use Zef;
 
 class Zef::Test does Pluggable {
-    method test($path, :@includes, Supplier :$stdout, Supplier :$stderr) {
+    method test($path, :@includes, Supplier :$logger) {
         die "Can't test non-existent path: {$path}" unless $path.IO.e;
         my $tester = self.plugins.first(*.test-matcher($path));
         die "No testing backend available" unless ?$tester;
 
-        $tester.stdout.Supply.act: -> $out { ?$stdout ?? $stdout.emit($out) !! $*OUT.say($out) }
-        $tester.stderr.Supply.act: -> $err { ?$stderr ?? $stderr.emit($err) !! $*ERR.say($err) }
+        if ?$logger {
+            $logger.emit({ level => DEBUG, stage => TEST, phase => START, payload => self, message => "Testing with plugin: {$tester.^name}" });
+            $tester.stdout.Supply.act: -> $out { $logger.emit({ level => VERBOSE, stage => EXTRACT, phase => LIVE, message => $out }) }
+            $tester.stderr.Supply.act: -> $err { $logger.emit({ level => ERROR,   stage => EXTRACT, phase => LIVE, message => $err }) }
+        }
 
         my @got = try $tester.test($path, :@includes);
 


### PR DESCRIPTION
Moves all previous output to `$*OUT` and `$*ERR` in `Zef::Client` to `Zef::CLI`, where `Zef::Client` communicates back status updates to `Zef::CLI` and `Zef::CLI` can then decide what type of output is appropriate to display. This opens up the possibility of a `Zef::GUI` front end that uses `Zef::Client` the same as `Zef::CLI`