### PR TITLE
Fix "Function 'BEFORE' needs parens to avoid gobbling block"

### DIFF
--- a/lib/Zef/CLI.pm6
+++ b/lib/Zef/CLI.pm6
@@ -1,3 +1,4 @@
+use Zef;
 use Zef::Client;
 use Zef::Config;
 use Zef::Utils::FileSystem;


### PR DESCRIPTION
Add missing use statement for the module which declares the enum.