### PR TITLE
Allow named options after positionals for CLI

### DIFF
--- a/lib/Zef/CLI.pm6
+++ b/lib/Zef/CLI.pm6
@@ -561,7 +561,7 @@ package Zef::CLI {
 
             my $arg-as  = $arg.subst(/^["--" | "--\/"]/, '');
             my $enabled = $arg.starts-with('--/') ?? 0 !! 1;
-            $arg.starts-with('--')
+            $arg.starts-with('-')
                 ?? $arg-as ~~ any($plugin-lookup.keys)
                     ?? (for |$plugin-lookup{$arg-as} -> $p { $p<enabled> = $enabled })
                     !! @named.append($arg)


### PR DESCRIPTION
These all do the same thing now:
`zef --force install CSV::Parser`
`zef install --force CSV::Parser`
`zef install CSV::Parser --force`

Resolves #109 