### PR TITLE
Default to Perl6 TAP::Harness for testing

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -114,17 +114,17 @@
     ],
     "Test" : [
         {
+            "short-name" : "tap-harness",
+            "module" : "Zef::Service::TAP",
+            "comment" : "Perl6 TAP::Harness adapter"
+        },
+        {
             "short-name" : "prove",
             "module" : "Zef::Service::Shell::prove"
         },
         {
-            "short-name" : "default-tester",
+            "short-name" : "perl6-test",
             "module" : "Zef::Service::Shell::Test"
-        },
-        {
-            "short-name" : "tap-harness",
-            "module" : "Zef::Service::TAP",
-            "comment" : "Buggy; Seems to not like dynamic module loading? (ex: HTTP::UserAgent t/090-ua-ssl.t)"
         }
     ]
 }


### PR DESCRIPTION
Some modules that pass with perl5 prove may fail with this (HTTP::UserAgent and LWP::UserAgent were encountering this due to how it skipped tests based on a dynamically loaded module - both have been patched).

You can test this with `zef --/tap-harness install My::Module`, which disables the perl6 TAP::Harness and falls back to the perl5 prove