### PR TITLE
Do not search for items installed with Rakudo

### DIFF
--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -108,7 +108,8 @@ class Zef::Client {
 
                 next unless my @needed = @specs-batch\               # The current set of specs
                     .grep({ not @skip.first(*.contains-spec($_)) })\ # Dists in @skip are not needed
-                    .grep({ not self.is-installed($_)            }); # Installed dists are not needed
+                    .grep({ not self.is-installed($_)            })\ # Installed dists are not needed
+                    .grep({ not @!ignore.first($_.spec) });          # Core dependencies
                 my @identities = @needed.map(*.identity);
                 self.logger.emit({
                     level   => INFO,


### PR DESCRIPTION
Currently, when I use zef to install distributions that depend on things distributed with rakudo (e.g., nqp), zef fails to install them because it cannot find the dependencies to install. This patch filters them out of the dependencies that zef attempts to install.