### PR TITLE
Improve Fetch reporting and functionality

### DIFF
--- a/lib/Zef/Fetch.pm6
+++ b/lib/Zef/Fetch.pm6
@@ -4,7 +4,14 @@ use Zef::Utils::URI;
 class Zef::Fetch does Pluggable {
     method fetch($uri, $save-as, Supplier :$logger) {
         my $fetchers := self.plugins.grep(*.fetch-matcher($uri)).cache;
-        die "No fetching backend available" unless $fetchers.head(1);
+
+        unless +$fetchers {
+            my @report_enabled  = self.plugins.map(*.short-name);
+            my @report_disabled = self.backends.map(*.<short-name>).grep({ $_ ~~ none(@report_enabled) });
+
+            die "Enabled fetching backends [{@report_enabled}] don't understand $uri\n"
+            ~   "You may need to configure one of the following backends, or install its underlying software - [{@report_disabled}]";
+        }
 
         my $got := $fetchers.map: -> $fetcher {
             if ?$logger {


### PR DESCRIPTION
* When a fetching backend can't be found to handle a url a more
helpful message is shown indicating the fetching backends that
failed as well as the fetching backends that are not enabled
or available (so if git is not installed `git` would be listed,
hopefully hinting to the user they need to install git)

* Improve mirror handling for Ecosystems so that if a mirror
fails OR the fetch process for a specific backend fails then
it will `note` the failure to fetch that mirror (due to previous
bullet point) and then attempt to fetch the next mirror.