### PR TITLE
Add license field to META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,6 +4,7 @@
     "version"     : "0.1.9",
     "auth"        : "github:ugexe",
     "description" : "It's like [cpanm] wearing high heels with a tracksuit",
+    "license"     : "Artistic-2.0",
     "depends"     : [ ],
     "provides"    : {
         "Zef"           : "lib/Zef.pm6",


### PR DESCRIPTION
This project has a LICENSE file, but the license of the project is not
designated in the META6.json file.