### PR TITLE
Optimize ecosystem fetching speed

### DIFF
--- a/lib/Zef/Service/Shell/curl.pm6
+++ b/lib/Zef/Service/Shell/curl.pm6
@@ -17,7 +17,7 @@ class Zef::Service::Shell::curl is Zef::Shell does Fetcher does Probeable does M
 
     method fetch($url, $save-as) {
         mkdir($save-as.IO.parent) unless $save-as.IO.parent.IO.e;
-        my $proc = $.zrun('curl', '--silent', '-L', '-o', $save-as, $url, :!out :!err);
-        $ = ?$proc ?? $save-as !! False;
+        my $proc = $.zrun('curl', '--silent', '-L', '-z', $save-as, '-o', $save-as, $url, :!out :!err);
+        $proc.so ?? $save-as !! False;
     }
 }

--- a/lib/Zef/Service/Shell/wget.pm6
+++ b/lib/Zef/Service/Shell/wget.pm6
@@ -16,8 +16,8 @@ class Zef::Service::Shell::wget is Zef::Shell does Fetcher does Probeable does M
     }
 
     method fetch($url, $save-as) {
-        mkdir($save-as.IO.parent) unless $save-as.IO.parent.IO.e;
-        my $proc = $.zrun('wget', '--quiet', $url, '-O', $save-as, :!out, :!err);
-        $ = ?$proc ?? $save-as !! False;
+        my $cwd = $save-as.IO.parent andthen {.IO.mkdir unless .IO.e};
+        my $proc = $.zrun('wget', '-N', '-P', $cwd, '--quiet', $url, '-O', $save-as, :!out, :!err, :$cwd);
+        $proc.so ?? $save-as !! False;
     }
 }

--- a/resources/config.json
+++ b/resources/config.json
@@ -76,12 +76,12 @@
             "module" : "Zef::Service::FetchPath"
         },
         {
-            "short-name" : "wget",
-            "module" : "Zef::Service::Shell::wget"
-        },
-        {
             "short-name" : "curl",
             "module" : "Zef::Service::Shell::curl"
+        },
+        {
+            "short-name" : "wget",
+            "module" : "Zef::Service::Shell::wget"
         },
         {
             "short-name" : "pswebrequest",

--- a/resources/scripts/win32http.ps1
+++ b/resources/scripts/win32http.ps1
@@ -1,13 +1,23 @@
-param (
-    [string]$url = $(throw "-url is required."),
-    [string]$out = $(throw "-out is required.")
+Param (
+    [Parameter(Mandatory=$True)] [System.Uri]$uri,
+    [Parameter(Mandatory=$True )] [string]$FilePath
 )
 
-$progressPreference = 'silentlyContinue' # hide progress output
-$http_proxy = $env:http_proxy;
-
-if ( $http_proxy -ne $null ) {
-    Invoke-WebRequest -Uri $url -OutFile $out -Proxy
+if ( -not (Test-Path $FilePath) ) {
+    [void] (New-Object System.Net.WebClient).DownloadFile($uri.ToString(), $FilePath)
 } else {
-    Invoke-WebRequest -Uri $url -OutFile $out    
+    try {
+        $webRequest = [System.Net.HttpWebRequest]::Create($uri);
+        $webRequest.IfModifiedSince = ([System.IO.FileInfo]$FilePath).LastWriteTime
+        $webRequest.Method = "GET";
+        [System.Net.HttpWebResponse]$webResponse = $webRequest.GetResponse()
+
+        $stream = New-Object System.IO.StreamReader($response.GetResponseStream())
+        $stream.ReadToEnd() | Set-Content -Path $FilePath -Force
+    } catch [System.Net.WebException] {
+        # If content isn't modified according to the output file timestamp then ignore the exception
+        if ($_.Exception.Response.StatusCode -ne [System.Net.HttpStatusCode]::NotModified) {
+            throw $_
+        }
+    }
 }


### PR DESCRIPTION
* Use Last-Modified-If'ish behavior for wget, curl, and the
powershell commandlet

* Prefer curl to wget (seems significantly faster)

This is the first step to speeding up auto-update. The next step
will be to only run auto-update every X hours (PRs welcome), since
the optimizations in this PR don't get around having to wait for
the http connect / header-response.