### PR TITLE
Try to cleanup tmp stuff

### DIFF
--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -2,6 +2,7 @@ use Zef;
 use Zef::Distribution;
 use Zef::Distribution::Local;
 use Zef::Repository;
+use Zef::Utils::FileSystem;
 
 use Zef::Fetch;
 use Zef::Extract;
@@ -273,14 +274,15 @@ class Zef::Client {
                     !! die("Aborting due to extract failure: {$candi.dist.?identity // $candi.uri} (use --force-extract to override)");
             }
             else {
+                try { delete-paths($candi.uri) }
+
                 self.logger.emit({
-                    level   => DEBUG,
+                    level   => VERBOSE,
                     stage   => EXTRACT,
                     phase   => AFTER,
                     payload => $candi,
                     message => "Extraction [OK]: {$candi.as} to {$extract-to}",
                 });
-
             }
 
             $candi.uri = $extracted-to;


### PR DESCRIPTION
If a fetch also does an extract which succeeds then its safe to
delete that path.

Unfortunately this will make git repos take longer to fetch when
updated, since the git repo itself will now be deleted after the
approriate files are in the store. But realistically we want
people to avoid using git repos as their source-url anyway, so
this is just another reason to use tarballs/cpan for releases.