### PR TITLE
Zef::Distribution: move BUILDALL -> TWEAK

### DIFF
--- a/lib/Zef/Distribution.pm6
+++ b/lib/Zef/Distribution.pm6
@@ -56,8 +56,7 @@ class Zef::Distribution is Distribution::DEPRECATED is Zef::Distribution::Depend
     # attach arbitrary data, like for topological sort, that won't be saved on install
     has %.metainfo is rw;
 
-    method BUILDALL(|) {
-        my $self = callsame;
+    method TWEAK(--> Nil) {
         # Distribution.new(|%meta6) causes fields like `"depends": [1, 2, 3]` to
         # get assigned such that `Distribution.depends.perl` -> `([1,2,3])` instead
         # of just `[1, 2, 3]`. Because its nice to pass in |%meta to the constructor
@@ -66,7 +65,6 @@ class Zef::Distribution is Distribution::DEPRECATED is Zef::Distribution::Depend
         @!test-depends  = @!test-depends.flatmap(*.flat);
         @!build-depends = @!build-depends.flatmap(*.flat);
         @!resources     = @!resources.flatmap(*.flat);
-        $self;
     }
 
     # make matching dependency names against a dist easier


### PR DESCRIPTION
Some of the details around BUILDALL have changed in recent versions of
rakudo for speed reasons.  Rather than adjusting our use of BUILDALL
here to handle the fact that it is now a multi, move over to using TWEAK
which seems to more-closely match what we are wanting to do here.

Without this change:

    % perl6 -Ilib bin/zef install .
    ===SORRY!=== Error while compiling /Users/aeruder/proj/rakudobuild/zef/lib/Zef/Distribution.pm6 (Zef::Distribution)
    Cannot have a multi candidate for 'BUILDALL' when an only method is also in the package 'Zef::Distribution'
    at /Users/aeruder/proj/rakudobuild/zef/lib/Zef/Distribution.pm6 (Zef::Distribution):48