### PR TITLE
Add "zef init" to options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 tmp/
 lib/.precomp/
 .precomp/
+# Emacs backups
+*~

--- a/README.pod
+++ b/README.pod
@@ -72,6 +72,9 @@ To install via rakudobrew, please use the following command:
     # launch browser to named support urls from meta data
     zef browse zef bugtracker
 
+    # Create META6.json using git repo info
+    zef init
+
 =head2 More CLI
 
 =head4 B<install> [*@identities]
@@ -278,6 +281,11 @@ Fetches candidates for given identities
 =head4 B<test> [*@paths]
 
 Run tests on each distribution located at [C<@paths>]
+
+=head4 B<init> 
+
+Run from the main directory in a distribution, generates C<META6.json>
+using information from the repository configuration.
 
 =head4 B<build> [*@paths]
 

--- a/lib/Zef/CLI.pm6
+++ b/lib/Zef/CLI.pm6
@@ -596,6 +596,62 @@ package Zef::CLI {
         exit 0;
     }
 
+    #| Create META6.json with sensible defaults
+    multi MAIN('init') {
+	if "META6.json".IO.e {
+	    say "'META6.json' already exists";
+	    exit 255;
+	}
+	# Find out if we are in a git directory
+	say "===> Generating META6.json";
+	my $auth = "";
+	my $server = "";
+	my $source-url = "";
+	if ".git/config".IO.e {
+	    my $git-config = ".git/config".IO.slurp;
+	    $source-url = ($git-config ~~  m{ \[remote \s+ \"origin\"\] \s+ url \s+ \= \s+ <(\S*)> });
+        }
+	    
+	if $source-url {
+	    say "===> Found source-url → $source-url";
+        }	
+
+	given $source-url {
+	      when "" { proceed }
+      	      when /\.com/ { ($server,$auth) = ($source-url ~~ /(\w+).com.(\w+)\//).list;  }
+      	      default { $auth = ($source-url ~~ m{\.\w+\/(\w+)\/}) }	
+	}
+	# " Closes quotes to allow syntax hiliting in emacs
+	my $meta-json = qq:to/END/;
+\{
+    "authors" : [
+	"Your name"
+    ],
+    "build-depends" : [ ],
+    "description" : "Give a description",
+    "name" : "Your Name",
+    "auth" : "{$server}:{$auth}",
+    "license" : "Provide a License",
+    "perl" : "6",
+    "provides" : \{ "Module": "lib/Module.pm6"  },
+    "tags" : [],
+    "resources" : [ ],
+    "source-url" : "{$source-url}",
+    "depends" : [
+    ],
+    "test-depends"  : [
+        "Test",
+        "Test::META"
+    ],
+    "version" : "0.0.3"
+}
+END
+
+        spurt("META6.json",$meta-json);	
+        say "Now edit META6.json to change defaults and add it to the repo";
+        exit 0;
+    }
+
     multi MAIN(Bool :h(:$help)?) {
         note qq:to/END_USAGE/
             Zef - Perl6 Module Management

--- a/lib/Zef/CLI.pm6
+++ b/lib/Zef/CLI.pm6
@@ -680,7 +680,8 @@ END
                 locate                  Lookup installed module information by short-name, name-path, or sha1 (with --sha1 flag)
                 smoke                   Run smoke testing on available modules
                 nuke                    Delete directory/prefix containing matching configuration path or CURLI name
-
+                init                    Creates META6.json using information from repo
+		
             OPTIONS
 
                 --install-to=[name]     Short name or spec of CompUnit::Repository to install to

--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -376,7 +376,7 @@ class Zef::Client {
                     ?? say('Failed to get passing tests, but continuing with --force-test')
                     !! die("Aborting due to test failure: {$candi.dist.?identity // $candi.uri // $candi.test-results } (use --force-test to override)");
 
-                die "Aborting due to test failure: {$candi.dist.?identity // $candi.as} "
+                die "Aborting due to test failure: {$candi.dist.?identity // $candi.as // $candi.test-results} "
                 ~   "(use --force-test to override)" unless ?$!force-test;
             }
             else {

--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -369,12 +369,12 @@ class Zef::Client {
                     stage   => TEST,
                     phase   => AFTER,
                     payload => $candi,
-                    message => "Testing [FAIL]: {$candi.dist.?identity // $candi.as}",
+                    message => "Testing [FAIL]: {$candi.dist.?identity // $candi.as // $candi.test-results}",
                 });
 
                 $!force-test
                     ?? say('Failed to get passing tests, but continuing with --force-test')
-                    !! die("Aborting due to test failure: {$candi.dist.?identity // $candi.uri} (use --force-test to override)");
+                    !! die("Aborting due to test failure: {$candi.dist.?identity // $candi.uri // $candi.test-results } (use --force-test to override)");
 
                 die "Aborting due to test failure: {$candi.dist.?identity // $candi.as} "
                 ~   "(use --force-test to override)" unless ?$!force-test;

--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -369,14 +369,14 @@ class Zef::Client {
                     stage   => TEST,
                     phase   => AFTER,
                     payload => $candi,
-                    message => "Testing [FAIL]: {$candi.dist.?identity // $candi.as // $candi.test-results}",
+                    message => "Testing [FAIL]: {$candi.dist.?identity // $candi.as}",
                 });
 
                 $!force-test
                     ?? say('Failed to get passing tests, but continuing with --force-test')
-                    !! die("Aborting due to test failure: {$candi.dist.?identity // $candi.uri // $candi.test-results } (use --force-test to override)");
+                    !! die("Aborting due to test failure: {$candi.dist.?identity // $candi.uri} (use --force-test to override)");
 
-                die "Aborting due to test failure: {$candi.dist.?identity // $candi.as // $candi.test-results} "
+                die "Aborting due to test failure: {$candi.dist.?identity // $candi.as} "
                 ~   "(use --force-test to override)" unless ?$!force-test;
             }
             else {


### PR DESCRIPTION
It would create a valid META6.json in the same directory, after looking at `.git/config` and extracting repo and author information. It will default to "" if this is not available, will bail out if META6.json is also present.
I also belong to the church of Emacs, which adds ~ to backup files; this has been added to .gitignore. Closes #219 when accepted. 