### PR TITLE
Ignore native depends

### DIFF
--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -129,6 +129,7 @@ class Zef::Client {
 
                 next unless my @needed = @specs-batch\               # The current set of specs
                     .grep({ not @skip.first(*.contains-spec($_)) })\ # Dists in @skip are not needed
+                    .grep(-> $spec { ($spec.from-matcher // '') eq ':from<bin>' })\
                     .grep(-> $spec { ($spec.from-matcher // '') eq ':from<native>' })\
                     .grep(-> $spec { not @!exclude.first({ $_.spec-matcher($spec) }) })\
                     .grep(-> $spec { not @!ignore.first({ $_.spec-matcher($spec) }) })\

--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -129,6 +129,7 @@ class Zef::Client {
 
                 next unless my @needed = @specs-batch\               # The current set of specs
                     .grep({ not @skip.first(*.contains-spec($_)) })\ # Dists in @skip are not needed
+                    .grep(-> $spec { ($spec.from-matcher // '') eq ':from<native>' })\
                     .grep(-> $spec { not @!exclude.first({ $_.spec-matcher($spec) }) })\
                     .grep(-> $spec { not @!ignore.first({ $_.spec-matcher($spec) }) })\
                     .grep({ $skip-installed ?? self.is-installed($_).not !! True });

--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -128,7 +128,6 @@ class Zef::Client {
                 });
                 next unless my @needed = @specs-batch\               # The current set of specs
                     .grep({ not @skip.first(*.contains-spec($_)) })\ # Dists in @skip are not needed
-                    .grep(-> $spec { ($spec.from-matcher // 'Perl6') eq 'Perl6' })\
                     .grep(-> $spec { not @!exclude.first({ $_.spec-matcher($spec) }) })\
                     .grep(-> $spec { not @!ignore.first({ $_.spec-matcher($spec) }) })\
                     .grep({ $skip-installed ?? self.is-installed($_).not !! True });

--- a/lib/Zef/Distribution/DependencySpecification.pm6
+++ b/lib/Zef/Distribution/DependencySpecification.pm6
@@ -8,7 +8,7 @@ class Zef::Distribution::DependencySpecification {
     submethod new($spec) { self.bless(:$spec) }
 
     method identity {
-        my $hash = %(:name($.name), :ver($.version-matcher), :auth($.auth-matcher), :api($.api-matcher));
+        my $hash = %(:name($.name), :ver($.version-matcher), :auth($.auth-matcher), :api($.api-matcher), :from($.from-matcher));
         my $identity = hash2identity( $hash );
         $identity;
     }
@@ -28,6 +28,8 @@ class Zef::Distribution::DependencySpecification {
     method auth-matcher    { self.spec-parts<auth> // ''  }
 
     method api-matcher     { self.spec-parts<api>  // '*' }
+
+    method from-matcher     { self.spec-parts<from>  // 'Perl6' }
 
     method !spec { $.spec || self.Str }
 

--- a/lib/Zef/Distribution/DependencySpecification.pm6
+++ b/lib/Zef/Distribution/DependencySpecification.pm6
@@ -29,7 +29,7 @@ class Zef::Distribution::DependencySpecification {
 
     method api-matcher     { self.spec-parts<api>  // '*' }
 
-    method from-matcher     { self.spec-parts<from>  // 'Perl6' }
+    method from-matcher     { self.spec-parts<from> // '' }
 
     method !spec { $.spec || self.Str }
 

--- a/lib/Zef/Identity.pm6
+++ b/lib/Zef/Identity.pm6
@@ -73,7 +73,7 @@ class Zef::Identity {
                     version => ~($ident<ver>     // ''),
                     auth    => ~($ident<auth>    // ''),
                     api     => ~($ident<api>     // ''),
-                    from    => ~($ident<from>    // 'Perl6'),
+                    from    => ~($ident<from>    || 'Perl6'),
                 );
             }
         }
@@ -91,8 +91,7 @@ class Zef::Identity {
         $!name
             ~ (($!version // '' ) ne ('*' | '') ?? ":ver<"  ~ ($!version.starts-with('v') ?? $!version.substr(1) !! $!version) ~ ">" !! '')
             ~ (($!auth    // '' ) ne ('*' | '') ?? ":auth<" ~ $!auth     ~ ">" !! '')
-            ~ (($!api     // '' ) ne ('*' | '') ?? ":api<"  ~ $!api      ~ ">" !! '')
-            ~ (($!from    // '' ) ne ('*' | '') ?? ":from<" ~ $!from     ~ ">" !! '');
+            ~ (($!api     // '' ) ne ('*' | '') ?? ":api<"  ~ $!api      ~ ">" !! '');
     }
 
     method hash {
@@ -101,6 +100,7 @@ class Zef::Identity {
         %hash<ver>  = $!version // '';
         %hash<auth> = $!auth    // '';
         %hash<api>  = $!api     // '';
+        %hash<from> = $!from    // '';
         %hash;
     }
 }

--- a/t/identity.t
+++ b/t/identity.t
@@ -35,11 +35,8 @@ subtest {
 subtest {
     my @variations = (
         "Net::HTTP:ver<1.0>:auth<github:ugexe>",
-        "Net::HTTP:ver('1.0'):auth<github:ugexe>",
-        "Net::HTTP:ver('1.0'):auth('github:ugexe')",
-        'Net::HTTP:ver("1.0"):auth("github:ugexe")',
-        "Net::HTTP:auth<github:ugexe>:ver(v1.0):api<>",
-        "Net::HTTP:ver(v1.0):api<>:auth<github:ugexe>";
+        "Net::HTTP:auth<github:ugexe>:ver<v1.0>:api<>",
+        "Net::HTTP:ver<v1.0>:api<>:auth<github:ugexe>";
     );
 
     for @variations -> $identity {
@@ -55,9 +52,6 @@ subtest {
 subtest {
     my @variations = (
         "Net::HTTP:ver<*>:auth<github:ugexe>",
-        "Net::HTTP:ver('*'):auth<github:ugexe>",
-        "Net::HTTP:ver('*'):auth('github:ugexe')",
-        'Net::HTTP:ver("*"):auth("github:ugexe")',
     );
 
     for @variations -> $identity {
@@ -73,11 +67,8 @@ subtest {
 subtest {
     my @variations = (
         "Net::HTTP:ver<1.0+>:auth<github:ugexe>",
-        "Net::HTTP:ver('1.0+'):auth<github:ugexe>",
-        "Net::HTTP:ver('1.0+'):auth('github:ugexe')",
-        'Net::HTTP:ver("1.0+"):auth("github:ugexe")',
-        "Net::HTTP:auth<github:ugexe>:ver(v1.0+):api<>",
-        "Net::HTTP:ver(v1.0+):api<>:auth<github:ugexe>";
+        "Net::HTTP:auth<github:ugexe>:ver<1.0+>:api<>",
+        "Net::HTTP:auth<github:ugexe>:ver<v1.0+>:api<>",
     );
 
     for @variations -> $identity {
@@ -110,7 +101,7 @@ subtest {
 
     subtest {
         my $expected  = "Net::HTTP:ver<1.0+>:auth<github:ugexe>";
-        my $require   = "Net::HTTP:ver('v1.0+'):auth<github:ugexe>";
+        my $require   = "Net::HTTP:ver<v1.0+>:auth<github:ugexe>:api<>";
         my $urn       = "github:ugexe:Net--HTTP:1.0+";
         my $i-require = str2identity($require);
         my $i-urn     = str2identity($urn);


### PR DESCRIPTION
Ignore dep specs that contain `:from<native>`, so that versions of zef with the yet-to-be-introduced functionality regarding native dependencies do not crash.