### PR TITLE
Fix zef locate with bin/ and resources/ file finding

### DIFF
--- a/lib/Zef/CLI.pm6
+++ b/lib/Zef/CLI.pm6
@@ -346,7 +346,6 @@ package Zef::CLI {
                         my $lib  = $libs.first({.key eq $identity});
                         say "===> From Distribution: {~$candi.dist}";
                         say "{$identity} => {$candi.from.prefix.child('resources').child($lib.value)}";
-                        exit 0;
                     }
                 }
             }


### PR DESCRIPTION
Before, it was only finding the first file matched if there were
multiple with the same name.

Fixes #244