### PR TITLE
Allow is-installed to search for :from<native> and :from<bin>

### DIFF
--- a/lib/Zef/Identity.pm6
+++ b/lib/Zef/Identity.pm6
@@ -89,9 +89,10 @@ class Zef::Identity {
     # Acme::Foo::SomeModule:auth<cpan:ugexe>:ver('1.0')
     method identity {
         $!name
-            ~ (($!version // '' ) ne ('*' | '') ?? ":ver<"  ~ ($!version.starts-with('v') ?? $!version.substr(1) !! $!version) ~ ">" !! '')
-            ~ (($!auth    // '' ) ne ('*' | '') ?? ":auth<" ~ $!auth     ~ ">" !! '')
-            ~ (($!api     // '' ) ne ('*' | '') ?? ":api<"  ~ $!api      ~ ">" !! '');
+            ~ (($!version // '' ) ne ('*' | '')     ?? ":ver<"  ~ ($!version.starts-with('v') ?? $!version.substr(1) !! $!version) ~ ">" !! '')
+            ~ (($!auth    // '' ) ne ('*' | '')     ?? ":auth<" ~ $!auth   ~ ">" !! '')
+            ~ (($!api     // '' ) ne ('*' | '')     ?? ":api<"  ~ $!api    ~ ">" !! '')
+            ~ (($!from    // '' ) ne ('Perl6' | '') ?? ":from<" ~ $!from   ~ ">" !! '');
     }
 
     method hash {

--- a/lib/Zef/Utils/FileSystem.pm6
+++ b/lib/Zef/Utils/FileSystem.pm6
@@ -54,3 +54,15 @@ sub lock-file-protect($path, &code, Bool :$shared = False) is export {
         code();
     }
 }
+
+our sub which($name) {
+    my $source-paths  := $*SPEC.path.grep(*.?chars).map(*.IO).grep(*.d);
+    my $path-guesses  := $source-paths.map({ $_.child($name) });
+    my $possibilities := $path-guesses.map: -> $path {
+        ((BEGIN $*DISTRO.is-win)
+            ?? ($path.absolute, %*ENV<PATHEXT>.split(';').map({ $path.absolute ~ $_ }).Slip)
+            !! $path.absolute).Slip
+    }
+
+    return $possibilities.grep(*.defined).grep(*.IO.f);
+}


### PR DESCRIPTION
For simple dependency lists authors can do "curl:from<native>" to
search for what rakudo thinks is "libcurl" for a given system, or
"curl:from<bin>" to do a `which` style lookup of a bin script.

These aren't very flexible ( how does one make :from<bin> also work
with :ver<...> for instance ) but will hopefully work to handle
simple tasks like filtering out non-windows-y stuff when running on
windows.