### PR TITLE
Add more useful error when dist is missing source-url

### DIFF
--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -180,6 +180,8 @@ class Zef::Client {
             });
 
             my $tmp      = $!config<TempDir>.IO.child("{time}.{$*PID}.{(^10000).pick(1)}");
+            die "Missing source URL in distribution"
+                unless $candi.uri;
             my $stage-at = $tmp.child($candi.uri.IO.basename);
             die "failed to create directory: {$tmp.absolute}"
                 unless ($tmp.IO.e || mkdir($tmp));


### PR DESCRIPTION
A user today had an issue installing a module: http://colabti.org/irclogger/irclogger_log/perl6?date=2018-07-23#l933

The original error was `No such method 'IO' for invocant of type 'Any'` and it took some time to find out that the dist's meta file had an empty source URL `"source-url" : "",`

This PR makes the error a bit more helpful:

```
$ perl6 -Ilib bin/zef install SeqSplitter                                                                                                                                                                 
===> Searching for: SeqSplitter
Missing source URL in distribution
```