### PR TITLE
Fix example for resources method

### DIFF
--- a/lib/Zef/Distribution/Local.pm6
+++ b/lib/Zef/Distribution/Local.pm6
@@ -48,7 +48,8 @@ class Zef::Distribution::Local is Zef::Distribution {
         # Example:
         #   META FILE: 'resources/libraries/mylib'
         #   GENERATED: 'resources/libraries/mylib' => 'resources/libaries/libmylib.so'
-        #           or 'resources/libraries/mylib' => 'resources/libaries/libmylib.dll'
+        #           or 'resources/libraries/mylib' => 'resources/libaries/mylib.dll'
+        # Note that it does not add the "lib" prefix on Windows. Whether the generated file has the "lib" prefix is platform dependent. 
         my $lib-path = $res-path.child('libraries');
 
         % = self.hash<resources>.map: -> $resource {

--- a/lib/Zef/Distribution/Local.pm6
+++ b/lib/Zef/Distribution/Local.pm6
@@ -47,8 +47,8 @@ class Zef::Distribution::Local is Zef::Distribution {
         # path to this new path so that CURI.install can understand it.
         # Example:
         #   META FILE: 'resources/libraries/mylib'
-        #   GENERATED: 'resources/libraries/mylib' => 'resources/libaries/mylib.so'
-        #           or 'resources/libraries/mylib' => 'resources/libaries/mylib.dll'
+        #   GENERATED: 'resources/libraries/mylib' => 'resources/libaries/libmylib.so'
+        #           or 'resources/libraries/mylib' => 'resources/libaries/libmylib.dll'
         my $lib-path = $res-path.child('libraries');
 
         % = self.hash<resources>.map: -> $resource {


### PR DESCRIPTION
HI,
I found that $*VM.platform-library-name adds "lib" prefix to the generated file when `$resources` starts with "libraries/" prefix.

Cheers,
