### PR TITLE
Fix fetching in BusyBox environment

### DIFF
--- a/lib/Zef/Service/Shell/wget.pm6
+++ b/lib/Zef/Service/Shell/wget.pm6
@@ -15,7 +15,7 @@ class Zef::Service::Shell::wget does Fetcher does Probeable does Messenger {
         react {
             my $cwd := $save-as.parent;
             my $ENV := %*ENV;
-            my $proc = zrun-async('wget', '-N', '-P', $cwd, '--quiet', $url, '-O', $save-as.absolute);
+            my $proc = zrun-async('wget', '-P', $cwd, '--quiet', $url, '-O', $save-as.absolute);
             whenever $proc.stdout(:bin) { }
             whenever $proc.stderr(:bin) { }
             whenever $proc.start(:$ENV, :$cwd) { $passed = $_.so }


### PR DESCRIPTION
BusyBox has its own version of wget which does not support the -N flag.
Fetching thus fails with that version. So we guard against that version
in the classic wget Fetcher and add another Fetcher that detects the
BusyBox version and does not use the -N flag.

This most prominently fixes zef on alpine linux which is most often used in docker containers.