### PR TITLE
Allow auto-update to be disabled on the command-line

### DIFF
--- a/lib/Zef/Repository/Ecosystems.pm6
+++ b/lib/Zef/Repository/Ecosystems.pm6
@@ -6,7 +6,7 @@ use Zef::Distribution::DependencySpecification;
 class Zef::Repository::Ecosystems does Repository {
     has $.name;
     has $.mirrors;
-    has $.auto-update;
+    has $.auto-update is rw;
 
     has $.fetcher;
     has $.cache;

--- a/lib/Zef/Repository/LocalCache.pm6
+++ b/lib/Zef/Repository/LocalCache.pm6
@@ -14,7 +14,7 @@ use Zef::Utils::FileSystem;
 #    made inside Zef::Repository itself)
 class Zef::Repository::LocalCache does Repository {
     has $.mirrors;
-    has $.auto-update;
+    has $.auto-update is rw;
     has $.cache;
     has @!dists;
 


### PR DESCRIPTION
Allows e.g. zef install Foo --/update (to not auto-update anything)
and zef install Foo --/update=p6c (to not auto-update just p6c).

Also allows `--update` (to force an update for all ecosystems)
and `--update=p6c` (to force an update for a specific ecosystem).