### PR TITLE
Add a better error message for invalid 'resources'

### DIFF
--- a/lib/Zef/Distribution/Local.pm6
+++ b/lib/Zef/Distribution/Local.pm6
@@ -53,6 +53,9 @@ class Zef::Distribution::Local is Zef::Distribution {
         my $lib-path = $res-path.child('libraries');
 
         % = self.hash<resources>.map: -> $resource {
+            unless $resource ~~ Str {
+                die "Every item in 'resources' Hash of META6.json must be a string, got $resource.^name() instead ('$resource.Str()')"
+            }
             my $resource-path = $resource ~~ m/^libraries\/(.*)/
                 ?? $lib-path.child($*VM.platform-library-name(IO::Path.new($0, :CWD($!path))))
                 !! $res-path.child($resource);


### PR DESCRIPTION
It caused some confusion at https://colabti.org/irclogger/irclogger_log/perl6?date=2019-06-08#l139