### PR TITLE
Fix parsing of auths from identities containing < or >

### DIFF
--- a/lib/Zef/Distribution.pm6
+++ b/lib/Zef/Distribution.pm6
@@ -121,7 +121,12 @@ class Zef::Distribution does Distribution is Zef::Distribution::DependencySpecif
     }
 
     method !long-name($name!) {
-        return "{$name}:ver<{$.ver  // ''}>:auth<{$.auth // ''}>:api<{$.api // ''}>";
+        return sprintf '%s:ver<%s>:auth<%s>:api<%s>',
+            $name,
+            (self.ver  // ''),
+            (self.auth // '').trans(['<', '>'] => ['\<', '\>']),
+            (self.api  // ''),
+        ;
     }
 
     method id() {

--- a/lib/Zef/Distribution/DependencySpecification.pm6
+++ b/lib/Zef/Distribution/DependencySpecification.pm6
@@ -3,9 +3,10 @@ use Zef::Identity;
 class Zef::Distribution::DependencySpecification {
     has $!ident;
     has $.spec;
-    # todo: handle wildcard/+ (like "1.2.3+", "1.2.*", "*:ugexe", "github:*")
 
-    submethod new($spec) { self.bless(:$spec) }
+    submethod TWEAK(:$!spec, :$!ident) { }
+    multi submethod new(Zef::Identity $ident) { self.bless(:$ident) }
+    multi submethod new($spec) { self.bless(:$spec) }
 
     method identity {
         my $hash = %(:name($.name), :ver($.version-matcher), :auth($.auth-matcher), :api($.api-matcher), :from($.from-matcher));

--- a/lib/Zef/Identity.pm6
+++ b/lib/Zef/Identity.pm6
@@ -15,7 +15,7 @@ class Zef::Identity {
 
         regex name  { <-restricted +name-sep>+ }
         token key   { <-restricted>+ }
-        token value { '<' ~ '>'  [<( [[ <!before \>|\\> . ]+]* % ['\\' . ] )>] }
+        regex value { '<' ~ '>' [<( [[ <!before \>|\<|\\> . ]+?]* %% ['\\' . ]+ )>] }
 
         token restricted { [':' | '<' | '>' | '(' | ')'] }
         token name-sep   { < :: > }
@@ -48,7 +48,7 @@ class Zef::Identity {
             self.bless(
                 name    => ~($ident<name>    // ''),
                 version => ~($ident<ver version>.first(*.defined) // ''),
-                auth    => ~($ident<auth>    // ''),
+                auth    => ~($ident<auth>    // '').trans(['\<', '\>'] => ['<', '>']),
                 api     => ~($ident<api>     // ''),
                 from    => ~($ident<from>    || 'Perl6'),
             );

--- a/t/identity.t
+++ b/t/identity.t
@@ -5,81 +5,81 @@ plan 6;
 use Zef::Identity;
 
 
-subtest {
+subtest 'Require spec - exact' => {
     my @variations = (
-        "Net::HTTP:ver<1.0>:auth<github:ugexe>",
-        "Net::HTTP:auth<github:ugexe>:ver<v1.0>:api<>",
+        'Net::HTTP:ver<1.0>:auth<Foo Bar \<f.bar@email.com\>>',
+        'Net::HTTP:auth<Foo Bar \<f.bar@email.com\>>:ver<1.0>:api<>',
     );
 
     for @variations -> $identity {
-        my $ident = Zef::Identity.new("Net::HTTP:ver<1.0>:auth<github:ugexe>");
+        my $ident = Zef::Identity.new($identity);
 
-        is $ident.auth,    'github:ugexe';
+        is $ident.auth,    'Foo Bar <f.bar@email.com>';
         is $ident.name,    'Net::HTTP';
         is $ident.version, '1.0';
     }
-}, 'Require spec - exact';
+}
 
 
-subtest {
+subtest 'Require spec - range *' => {
     my @variations = (
         "Net::HTTP:ver<*>:auth<github:ugexe>",
     );
 
     for @variations -> $identity {
-        my $ident = Zef::Identity.new("Net::HTTP:ver<*>:auth<github:ugexe>");
+        my $ident = Zef::Identity.new($identity);
 
         is $ident.auth,    'github:ugexe';
         is $ident.name,    'Net::HTTP';
         is $ident.version, '*';
     }
-}, 'Require spec - range *';
+}
 
 
-subtest {
+subtest 'Require spec - range +' => {
     my @variations = (
         "Net::HTTP:ver<1.0+>:auth<github:ugexe>",
         "Net::HTTP:auth<github:ugexe>:ver<1.0+>:api<>",
     );
 
     for @variations -> $identity {
-        my $ident = Zef::Identity.new("Net::HTTP:ver<1.0+>:auth<github:ugexe>");
+        my $ident = Zef::Identity.new($identity);
 
         is $ident.auth,    'github:ugexe';
         is $ident.name,    'Net::HTTP';
         is $ident.version, '1.0+';
     }
-}, 'Require spec - range +';
+}
 
 
-subtest {
+subtest 'str2identity' => {
     ok ?str2identity("***not valid***");
 
-    subtest {
+    subtest 'exact' => {
         my $expected  = "Net::HTTP:ver<1.0+>:auth<github:ugexe>";
         my $require   = "Net::HTTP:ver<1.0+>:auth<github:ugexe>:api<>";
         my $i-require = str2identity($require);
 
         is $i-require, $expected;
-    }, 'exact';
+    }
 
-    subtest {
+    subtest 'not exact' => {
         my $require = "Net::HTTP";
         my $i-require = str2identity($require);
 
         is $i-require, 'Net::HTTP';
-    }, 'not exact';
+    }
 
-    subtest {
+    subtest 'root namespace' => {
         my $require = "HTTP";
         my $i-require = str2identity($require);
 
         is $i-require, 'HTTP';
-    }, 'root namespace';
-}, 'str2identity';
+    }
+}
 
 
-subtest {
+subtest 'identity2hash' => {
     my $require = "Net::HTTP:ver<1.0+>:auth<github:ugexe>";
     my %hash    = %( :name<Net::HTTP>, :ver<1.0+>, :auth<github:ugexe> );
     ok ?identity2hash("***not valid***");
@@ -89,10 +89,10 @@ subtest {
     is %i-require<name>, 'Net::HTTP';
     is %i-require<ver>,  '1.0+';
     is %i-require<auth>, 'github:ugexe';
-}, 'identity2hash';
+}
 
 
-subtest {
+subtest 'hash2identity' => {
     my $require = "Net::HTTP:ver<1.0+>:auth<github:ugexe>";
     my %hash    = %( :name<Net::HTTP>, :ver<1.0+>, :auth<github:ugexe> );
     ok ?hash2identity("***not valid***");
@@ -100,4 +100,4 @@ subtest {
     my $i-require = hash2identity(%hash);
 
     is $i-require, "Net::HTTP:ver<1.0+>:auth<github:ugexe>";
-}, 'hash2identity';
+}


### PR DESCRIPTION
Previously searching for a name of a module (not a distribution
name) any auth that would contain a < or > would cause any
matching to fail. This fixes the grammar to properly parse
such characters in an identity string, as well as changing
how identities are constructed for provides to avoid parsing
from a string (instead setting the attributes directly).

Resolves #327