### PR TITLE
Notify when backends are not configured

### DIFF
--- a/lib/Zef/Fetch.pm6
+++ b/lib/Zef/Fetch.pm6
@@ -17,8 +17,9 @@ class Zef::Fetch does Pluggable {
             my @report_enabled  = self.plugins.map(*.short-name);
             my @report_disabled = self.backends.map(*.<short-name>).grep({ $_ ~~ none(@report_enabled) });
 
-            die "Enabled fetching backends [{@report_enabled}] don't understand $uri\n"
+            note "Enabled fetching backends [{@report_enabled}] don't understand $uri\n"
             ~   "You may need to configure one of the following backends, or install its underlying software - [{@report_disabled}]";
+            die;
         }
 
         my $got := $fetchers.map: -> $fetcher {

--- a/lib/Zef/Fetch.pm6
+++ b/lib/Zef/Fetch.pm6
@@ -17,9 +17,8 @@ class Zef::Fetch does Pluggable {
             my @report_enabled  = self.plugins.map(*.short-name);
             my @report_disabled = self.backends.map(*.<short-name>).grep({ $_ ~~ none(@report_enabled) });
 
-            note "Enabled fetching backends [{@report_enabled}] don't understand $uri\n"
+            die "Enabled fetching backends [{@report_enabled}] don't understand $uri\n"
             ~   "You may need to configure one of the following backends, or install its underlying software - [{@report_disabled}]";
-            die;
         }
 
         my $got := $fetchers.map: -> $fetcher {

--- a/lib/Zef/Fetch.pm6
+++ b/lib/Zef/Fetch.pm6
@@ -43,3 +43,4 @@ class Zef::Fetch does Pluggable {
         return $got.first(*.so);
     }
 }
+

--- a/lib/Zef/Repository/Ecosystems.pm6
+++ b/lib/Zef/Repository/Ecosystems.pm6
@@ -37,9 +37,10 @@ class Zef::Repository::Ecosystems does Repository {
             UNDO note "!!!> Failed to update $!name mirror: $uri";
             KEEP note "===> Updated $!name mirror: $uri";
             KEEP self!gather-dists;
+            CATCH { .note; }
 
             my $save-as  = $!cache.IO.child($uri.IO.basename);
-            my $saved-as = try $!fetcher.fetch(Candidate.new(:$uri), $save-as, :timeout(180));
+            my $saved-as = $!fetcher.fetch(Candidate.new(:$uri), $save-as, :timeout(180));
             next unless $saved-as.?chars && $saved-as.IO.e;
 
             # this is kinda odd, but if $path is a file, then its fetching via http from p6c.org

--- a/lib/Zef/Repository/Ecosystems.pm6
+++ b/lib/Zef/Repository/Ecosystems.pm6
@@ -37,10 +37,12 @@ class Zef::Repository::Ecosystems does Repository {
             UNDO note "!!!> Failed to update $!name mirror: $uri";
             KEEP note "===> Updated $!name mirror: $uri";
             KEEP self!gather-dists;
-            CATCH { .note; }
 
             my $save-as  = $!cache.IO.child($uri.IO.basename);
-            my $saved-as = $!fetcher.fetch(Candidate.new(:$uri), $save-as, :timeout(180));
+            my $saved-as = try {
+                $!fetcher.fetch(Candidate.new(:$uri), $save-as, :timeout(180));
+                CATCH { default { .note; } }
+            }
             next unless $saved-as.?chars && $saved-as.IO.e;
 
             # this is kinda odd, but if $path is a file, then its fetching via http from p6c.org

--- a/lib/Zef/Repository/Ecosystems.pm6
+++ b/lib/Zef/Repository/Ecosystems.pm6
@@ -40,8 +40,8 @@ class Zef::Repository::Ecosystems does Repository {
 
             my $save-as  = $!cache.IO.child($uri.IO.basename);
             my $saved-as = try {
-                $!fetcher.fetch(Candidate.new(:$uri), $save-as, :timeout(180));
                 CATCH { default { .note; } }
+                $!fetcher.fetch(Candidate.new(:$uri), $save-as, :timeout(180));
             }
             next unless $saved-as.?chars && $saved-as.IO.e;
 


### PR DESCRIPTION
Use a log message rather than dying, which causes the error message to be lost.

This is a hotfix for https://github.com/ugexe/zef/issues/338