### PR TITLE
Centralize logging

### DIFF
--- a/lib/Zef/Client.pm6
+++ b/lib/Zef/Client.pm6
@@ -11,6 +11,7 @@ use Zef::Build;
 use Zef::Test;
 use Zef::Install;
 use Zef::Report;
+use Zef::Logger;
 
 class Zef::Client {
     has $.cache;
@@ -24,7 +25,7 @@ class Zef::Client {
     has $.reporter;
     has $.config;
 
-    has $.logger = Supplier.new;
+    has $.logger = Zef::Logger::get-logger;
 
     has @.exclude; # user supplied
     has @!ignore;  # internal use

--- a/lib/Zef/Logger.pm6
+++ b/lib/Zef/Logger.pm6
@@ -1,0 +1,15 @@
+use v6;
+
+unit module Zef::Logger;
+
+my $logger = Nil;
+
+our sub get-logger() {
+    $logger = Supplier.new unless $logger;
+    return $logger;
+}
+
+our sub register-listener(&f) {
+    get-logger.Supply.tap(&f);
+}
+

--- a/t/logger.t
+++ b/t/logger.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+plan 1;
+
+use Zef;
+use Zef::Logger;
+
+subtest 'Zef::Logger::get-logger' => {
+
+    subtest 'logger is singleton' => {
+        my $a = Zef::Logger::get-logger;
+        my $b = Zef::Logger::get-logger;
+        ok $a === $b;
+    }
+
+    subtest 'logger can send a message' => {
+        my $logger = Zef::Logger::get-logger;
+        my @log-entry;
+        Zef::Logger::register-listener({@log-entry = @_;});
+        $logger.emit({
+            level   => DEBUG,
+            stage   => TEST,
+            phase   => LIVE,
+            message => "A debug message",
+        });
+        ok @log-entry = (DEBUG, TEST, LIVE, "A debug message");
+    }
+
+    subtest 'logger can send another message' => {
+        my $logger = Zef::Logger::get-logger;
+        my @log-entry;
+        Zef::Logger::register-listener({
+            @log-entry = @_;
+        });
+        $logger.emit({
+            level   => WARN,
+            stage   => RESOLVE,
+            phase   => BEFORE,
+            message => "Hark, a warning message",
+        });
+        ok @log-entry = (WARN, RESOLVE, BEFORE, "Hark, a warning message");
+    }
+
+}
+
+done-testing;


### PR DESCRIPTION
Added a basic logger module and instructed Zef::Client to use it instead of creating a new Supplier.

The module definitely doesn't do anything fancy and is probably not thread-safe, so feedback is more than welcome 😃