### PR TITLE
Fix Zef on Windows with a Rakudo located in a path with spaces

### DIFF
--- a/lib/Zef.pm6
+++ b/lib/Zef.pm6
@@ -1,10 +1,7 @@
 class Zef { }
 
-my @zrun-invoke = BEGIN $*DISTRO.is-win
-    ?? ((%*ENV.first({.key.lc eq 'comspec'}).?value // 'cmd.exe').Str,  '/x/d/c')
-    !! '';
-sub zrun(*@_, *%_) is export { run (|@zrun-invoke, |@_).grep(*.?chars), |%_ }
-sub zrun-async(*@_, *%_) is export { Proc::Async.new( (|@zrun-invoke, |@_).grep(*.?chars), |%_ ) }
+sub zrun(*@_, *%_) is export { run (|@_).grep(*.?chars), |%_ }
+sub zrun-async(*@_, *%_) is export { Proc::Async.new( (|@_).grep(*.?chars), |%_ ) }
 
 # rakudo must be able to parse json, so it doesn't
 # make sense to require a dependency to parse it


### PR DESCRIPTION
I left the `zrun` wrappers intact. I'd let some time pass before removing them in case it turns out we need them after all.

I tested this on Windows by installing Zef into a precompiled rakudo 2020.02.1 in `C:\data\rakudo 2020.02.1` and installing `OO::Monitors` afterwards.

Fixes #337 