### PR TITLE
Change Rakudobrew -> Rakubrew in README.md

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -18,11 +18,11 @@ Raku / Perl6 Module Management
     $ cd zef
     $ perl6 -I. bin/zef install .
 
-=head4 Rakudobrew
+=head4 Rakubrew
 
-To install via rakudobrew, please use the following command:
+To install via rakubrew, please use the following command:
 
-    $ rakudobrew build zef
+    $ rakubrew build-zef
 
 =head1 USAGE
 
@@ -267,10 +267,10 @@ B<Options>
 List known available distributions
 
     $ zef --installed list
-    ===> Found via /home/nickl/.rakudobrew/moar-master/install/share/perl6/site
+    ===> Found via /home/nickl/.rakubrew/moar-master/install/share/perl6/site
     CSV::Parser:ver<0.1.2>:auth<github:tony-o>
     Zef:auth<github:ugexe>
-    ===> Found via /home/nickl/.rakudobrew/moar-master/install/share/perl6
+    ===> Found via /home/nickl/.rakubrew/moar-master/install/share/perl6
     CORE:ver<6.c>:auth<perl>
 
 Note that not every Repository may provide such a list, and such lists may only


### PR DESCRIPTION
Rakudobrew has been renamed to Rakubrew, so adapt the documentation
accordingly.