### PR TITLE
Correctly handle ssh-style git uris

### DIFF
--- a/lib/Zef/Service/Shell/git.pm6
+++ b/lib/Zef/Service/Shell/git.pm6
@@ -143,7 +143,8 @@ class Zef::Service::Shell::git does Probeable does Messenger {
 
     method !repo-url($url) {
         my $uri = uri($!scheme ?? $url.subst(/^\w+ '://'/, "{$!scheme}://") !! $url) || return False; #'
-        ($uri.scheme // '') ~ '://' ~ ($uri.host // '') ~ ($uri.path // '').subst(/\@.*[\/|\@|\?|\#]?$/, '');
+        my $reconstructed-uri = ($uri.scheme // '') ~ '://' ~ ($uri.user-info ?? "{$uri.user-info}@" !! '') ~ ($uri.host // '') ~ ($uri.path // '').subst(/\@.*[\/|\@|\?|\#]?$/, '');
+        return $reconstructed-uri;
     }
 
     method !checkout-name($url) {


### PR DESCRIPTION
While we don't explicitly support this uri format, allowing it to work is simply a matter of passing the user-info along to the plugin.

Resolves #359