### PR TITLE
Add hash dependency parsing for test/build depends

### DIFF
--- a/lib/Zef/Distribution.pm6
+++ b/lib/Zef/Distribution.pm6
@@ -74,13 +74,13 @@ class Zef::Distribution does Distribution is Zef::Distribution::DependencySpecif
         return system-collapse($.depends){$type}.grep(*.defined).grep(*.<requires>).map(*.<requires>).map(*.Slip).Slip;
     }
     method !depends2specs(*@depends) {
-        @depends.grep(*.Slip).grep(*.defined).map({ Zef::Distribution::DependencySpecification.new($_) }).grep(*.name);
+        @depends.map(*.Slip).grep(*.defined).map({ Zef::Distribution::DependencySpecification.new($_) }).grep(*.name);
     }
 
     method depends-specs {
         my $depends := system-collapse($.depends);
         my $deps    := $.depends ~~ Hash ?? self!new-depends('runtime') !! $depends;
-        return self!depends2specs($.depends ~~ Hash ?? $deps !! |$deps);
+        return self!depends2specs($deps);
     }
     method build-depends-specs {
         my $orig-build-depends := system-collapse($.build-depends);

--- a/lib/Zef/Distribution.pm6
+++ b/lib/Zef/Distribution.pm6
@@ -74,7 +74,8 @@ class Zef::Distribution does Distribution is Zef::Distribution::DependencySpecif
         return system-collapse($.depends){$type}.grep(*.defined).grep(*.<requires>).map(*.<requires>).map(*.Slip).Slip;
     }
     method !depends2specs(*@depends) {
-        @depends.map(*.Slip).grep(*.defined).map({ Zef::Distribution::DependencySpecification.new($_) }).grep(*.name);
+        my $depends       := @depends.map({$_ ~~ List ?? $_.Slip !! $_ }).grep(*.defined);
+        my $depends-specs := $depends.map({ Zef::Distribution::DependencySpecification.new($_) }).grep(*.name);
     }
 
     method depends-specs {

--- a/t/distribution-depends-parsing.t
+++ b/t/distribution-depends-parsing.t
@@ -55,7 +55,7 @@ with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $
                         "by-distro.name": {
                             "win32": ["Foo::Win32_1", "Foo::Win32_2"],
                             "linux": ["Foo::Linux_1", "Foo::Linux_2"],
-                            "" : ["Foo::Unknown", "Foo::Unknown_2"]
+                            "" : ["Foo::Unknown_1", "Foo::Unknown_2"]
                         }
                     }
                 ]

--- a/t/distribution-depends-parsing.t
+++ b/t/distribution-depends-parsing.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 34;
+plan 36;
 
 use Zef;
 use Zef::Client;
@@ -53,9 +53,9 @@ with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $
                 "requires" : [
                     {
                         "by-distro.name": {
-                            "win32": "Foo::Win32",
-                            "linux": "Foo::Linux",
-                            "" : "Foo::Unknown"
+                            "win32": ["Foo::Win32_1", "Foo::Win32_2"],
+                            "linux": ["Foo::Linux_1", "Foo::Linux_2"],
+                            "" : ["Foo::Unknown", "Foo::Unknown_2"]
                         }
                     }
                 ]
@@ -64,7 +64,9 @@ with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $
         "provides": { }
     }
     META6
-    ok any($dist.depends-specs.map(*.name)) ~~ any("Foo::Win32", "Foo::Linux", "Foo::Unknown");
+    is $dist.depends-specs.elems, 2;
+    ok any($dist.depends-specs.map(*.name)) ~~ any("Foo::Win32_1", "Foo::Linux_2", "Foo::Unknown_2");
+    ok any($dist.depends-specs.map(*.name)) ~~ any("Foo::Win32_1", "Foo::Linux_2", "Foo::Unknown_2");
     ok any($dist.depends-specs.map(*.from-matcher)) ~~ 'Perl6';
 }
 

--- a/t/distribution-depends-parsing.t
+++ b/t/distribution-depends-parsing.t
@@ -65,8 +65,8 @@ with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $
     }
     META6
     is $dist.depends-specs.elems, 2;
-    ok any($dist.depends-specs.map(*.name)) ~~ any("Foo::Win32_1", "Foo::Linux_2", "Foo::Unknown_2");
-    ok any($dist.depends-specs.map(*.name)) ~~ any("Foo::Win32_1", "Foo::Linux_2", "Foo::Unknown_2");
+    ok any($dist.depends-specs.map(*.name)) ~~ any("Foo::Win32_1", "Foo::Linux_1", "Foo::Unknown_1");
+    ok any($dist.depends-specs.map(*.name)) ~~ any("Foo::Win32_2", "Foo::Linux_2", "Foo::Unknown_2");
     ok any($dist.depends-specs.map(*.from-matcher)) ~~ 'Perl6';
 }
 


### PR DESCRIPTION
Allows for build and test dependencies to be declared in the hash form of `depends`. If both fields are use then we combine them.