### PR TITLE
Remove unneeded concurrency to speed up dependency resolution

### DIFF
--- a/lib/Zef/Repository/Ecosystems.pm6
+++ b/lib/Zef/Repository/Ecosystems.pm6
@@ -67,12 +67,7 @@ class Zef::Repository::Ecosystems does Repository {
         my @searchable-identities = %specs.classify({ .value.from-matcher })<Perl6>.grep(*.defined).hash.keys;
         return ().Seq unless @searchable-identities;
 
-        # XXX: Delete this eventually
-        my $dispatchers := $*PERL.compiler.version < v2018.08
-            ?? self!gather-dists
-            !! self!gather-dists.race;
-
-        my @matches = $dispatchers.map: -> $dist {
+        my @matches = self!gather-dists.map: -> $dist {
             @searchable-identities.grep({ $dist.contains-spec(%specs{$_}, :$strict) }).map({
                 Candidate.new(
                     dist => $dist,


### PR DESCRIPTION
Previously we used race to use multiple workers to grep through
a single ecosystems list of distributions. This removes the
concurrency, which results in a 30% reduction in runtime when
installing HTTP::UserAgent.