### PR TITLE
Print help text on stdout

### DIFF
--- a/lib/Zef/CLI.pm6
+++ b/lib/Zef/CLI.pm6
@@ -728,7 +728,7 @@ package Zef::CLI {
     }
 
     multi MAIN(Bool :h(:$help)?) {
-        note qq:to/END_USAGE/
+        say qq:to/END_USAGE/
             Zef - Raku / Perl6 Module Management
 
             USAGE


### PR DESCRIPTION
Currently help text is sent on stderr which makes it harder to redirect
or pipe to a pager (eg. `zef help 2>&1 | less`).  Since there is no
error involved it is safe to use stdout.