### PR TITLE
Fix missing build-result during build phase

### DIFF
--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -676,6 +676,8 @@ class Zef::Client {
 
             my $result := $!builder.build($candi, :includes($candi.dist.metainfo<includes> // []), :$!logger, :timeout($!build-timeout)).cache;
 
+            $candi.build-results = $result;
+
             if $result.grep(*.not).elems {
                 self.logger.emit({
                     level   => ERROR,


### PR DESCRIPTION
This appears to have been accidentally removed in v0.10.0, and
was resulting in `zef build .` reporting build failures despite
the build working.

Resolves #389