### PR TITLE
Allow dependency confusion mitigation by grouping ecosystems

### DIFF
--- a/lib/Zef.rakumod
+++ b/lib/Zef.rakumod
@@ -117,8 +117,15 @@ package Zef {
             +@names ?? self!list-plugins.grep({@names.contains(.short-name)}) !! self!list-plugins;
         }
 
-        method !list-plugins {
-            gather for @!backends -> $plugin {
+        method !list-plugins(@backends = @!backends) {
+            gather for @backends -> $plugin {
+                # a hack to allow the array of array backends to work (for Zef::Repository)
+                unless $plugin ~~ Hash {
+                    my $plugins := self!list-plugins($plugin);
+                    take $plugins;
+                    next;
+                }
+
                 my $module = $plugin<module>;
                 DEBUG($plugin, "Checking: {$module}");
 

--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -325,10 +325,9 @@ class Zef::Client {
         :$!installer              = Zef::Install.new(:backends(|%!config<Install>)),
         :$!tester                 = Zef::Test.new(:backends(|%!config<Test>)),
         :$!reporter               = Zef::Report.new(:backends(|%!config<Report>)),
-        :$!recommendation-manager = Zef::Repository.new(:backends(%!config<Repository>.map({ $_<options><cache> //= $!cache; $_<options><fetcher> = $!fetcher; $_ }).Slip)),
+        :$!recommendation-manager = Zef::Repository.new(:backends(%!config<Repository>.tree({$_}, *.map({ $_<options><cache> //= $!cache; $_<options><fetcher> = $!fetcher; $_ })).Array)),
     ) {
         mkdir $!cache unless $!cache.IO.e;
-
         # Ignore CORE modules to speed up searches and to avoid dual-life issues until CORE is more strictly versioned
         @!ignore = CompUnit::RepositoryRegistry
                     .repository-for-name('core')
@@ -488,6 +487,7 @@ class Zef::Client {
             }
         }
 
+# check $prereqs to see if we have any unneeded depends
         my Candidate @results = $prereqs.unique(:as(*.dist.identity));
         return @results;
     }

--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -29,17 +29,19 @@ class Zef::Repository does PackageRepository does Pluggable {
         # be done in Zef::Repository)
         my $repo = Zef::Repository.new(
             backends => [
-                {
-                    module     => "Zef::Repository::Ecosystems",
-                    options => {
-                        cache       => $cache,
-                        fetcher     => $fetcher,
-                        name        => "cpan",
-                        auto-update => 1,
-                        mirrors     => ["https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/11efd9077b398df3766eaa7cf8e6a9519f63c272/cpan.json"]
-                    }
-                },
-            ],
+                [
+                    {
+                        module     => "Zef::Repository::Ecosystems",
+                        options => {
+                            cache       => $cache,
+                            fetcher     => $fetcher,
+                            name        => "cpan",
+                            auto-update => 1,
+                            mirrors     => ["https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/11efd9077b398df3766eaa7cf8e6a9519f63c272/cpan.json"]
+                        }
+                    },
+                ],
+            ]
         );
 
         # Print out all available distributions from all supplied backend repositories
@@ -75,6 +77,11 @@ class Zef::Repository does PackageRepository does Pluggable {
     This module purposely does not combine multiple ecosystems into a single list to make a recommendation from; by design it a recommendation
     manager for the results of recommendation managers. This allows more consistent resolution of dependencies and integration with MetaCPAN like
     services (which may not just provide an entire list of modules it has -- i.e. it makes it own recommendation for a name)
+
+    One difference in how recommendations are made from raku is that repos are grouped. Given pseudo backends C<[[Eco1,Eco2],[Eco3]]> we see three
+    repository backends in two different groups -- ecosystems in later groups are only searched if previous groups found no matches. This allows
+    users to avoid dependency confusion attacks by allowing custom ecosystems to be the preferred source for whatever namespaces it provides
+    regardless if another ecosystem later provides a module by the same name but higher version number.
 
     Returns an C<Array> of C<Candidate>, where each C<Candidate> matches exactly one of the provided C<@identities> (and
     each C<@identities> matches zero or one of the C<Candidate>).
@@ -131,15 +138,25 @@ class Zef::Repository does PackageRepository does Pluggable {
         # todo: have a `file` identity in Zef::Identity
         my @searchable = @identities.grep({ not $_.starts-with("." | "/") });
 
-        # XXX: Delete this eventually
-        my $dispatchers := $*PERL.compiler.version < v2018.08
-            ?? self!plugins
-            !! self!plugins.race(:batch(1)); # a new thread per Repository backend we will search with below
-
         # Search each Repository / backend
-        my @unsorted-candis = $dispatchers.map: -> $storage {
-            my @search-for = $storage.id eq 'Zef::Repository::LocalCache' ?? @identities !! @searchable;
-            $storage.search(@search-for, :strict).Slip
+        # TODO: this currently just checks `if @group-results.elems` to decide if it should iterate to the next
+        # group, but since the search is for multiple module names we actually need to keep track of what specifically
+        # to look for in e.g. the second group
+        my @unsorted-candis = eager gather GROUP: for self!plugins -> @repo-group {
+            # XXX: Delete this eventually
+            my $dispatchers := $*PERL.compiler.version < v2018.08
+                ?? @repo-group
+                !! @repo-group.race(:batch(1)); # a new thread per Repository backend we will search with below
+
+            my @group-results = $dispatchers.race(:batch(1)).map: -> $repo {
+                my @search-for = $repo.id eq 'Zef::Repository::LocalCache' ?? @identities !! @searchable;
+                $repo.search(@search-for, :strict).Slip;
+            }
+            if @group-results.elems {
+                take $_ for @group-results;
+                last GROUP;
+            }
+
         }
 
         my @unsorted-grouped-candis = @unsorted-candis.categorize({.as}).values;
@@ -168,8 +185,8 @@ class Zef::Repository does PackageRepository does Pluggable {
 
         # XXX: Delete this eventually
         my $dispatcher := $*PERL.compiler.version < v2018.08
-            ?? self!plugins
-            !! self!plugins.race(:batch(1)); # a new thread per Repository backend we will search with below
+            ?? self!plugins.map(*.Slip)
+            !! self!plugins.map(*.Slip).race(:batch(1)); # a new thread per Repository backend we will search with below
 
         my @unsorted-candis = $dispatcher.map: -> $storage {
             $storage.search(@identities, |%fields, :$max-results, :$strict).Slip

--- a/resources/config.json
+++ b/resources/config.json
@@ -23,53 +23,57 @@
         }
     ],
     "Repository" : [
-        {
-            "short-name": "fez",
-            "enabled": 1,
-            "module": "Zef::Repository::Ecosystems",
-            "options": {
-                "name": "fez",
-                "auto-update": 1,
-                "uses-path": true,
-                "mirrors": [
-                    "http://360.zef.pm/"
-                ]
+        [
+            {
+                "short-name": "fez",
+                "enabled": 1,
+                "module": "Zef::Repository::Ecosystems",
+                "options": {
+                    "name": "fez",
+                    "auto-update": 1,
+                    "uses-path": true,
+                    "mirrors": [
+                        "http://360.zef.pm/"
+                    ]
+                }
+            },
+            {
+                "short-name" : "cached",
+                "enabled" : 1,
+                "module" : "Zef::Repository::LocalCache",
+                "options" : { }
             }
-        },
-        {
-            "short-name" : "cached",
-            "enabled" : 1,
-            "module" : "Zef::Repository::LocalCache",
-            "options" : { }
-        },
-        {
-            "short-name" : "cpan",
-            "enabled" : 1,
-            "module" : "Zef::Repository::Ecosystems",
-            "options" : {
-                "name" : "cpan",
-                "auto-update" : 1,
-                "mirrors" : [
-                    "https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/cpan1.json",
-                    "https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/cpan.json",
-                    "git://github.com/ugexe/Perl6-ecosystems.git"
-                ]
+        ],
+        [
+            {
+                "short-name" : "cpan",
+                "enabled" : 1,
+                "module" : "Zef::Repository::Ecosystems",
+                "options" : {
+                    "name" : "cpan",
+                    "auto-update" : 1,
+                    "mirrors" : [
+                        "https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/cpan1.json",
+                        "https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/cpan.json",
+                        "git://github.com/ugexe/Perl6-ecosystems.git"
+                    ]
+                }
+            },
+            {
+                "short-name" : "p6c",
+                "enabled" : 1,
+                "module" : "Zef::Repository::Ecosystems",
+                "options" : {
+                    "name" : "p6c",
+                    "auto-update" : 1,
+                    "mirrors" : [
+                        "https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/p6c1.json",
+                        "git://github.com/ugexe/Perl6-ecosystems.git",
+                        "http://ecosystem-api.p6c.org/projects1.json"
+                    ]
+                }
             }
-        },
-        {
-            "short-name" : "p6c",
-            "enabled" : 1,
-            "module" : "Zef::Repository::Ecosystems",
-            "options" : {
-                "name" : "p6c",
-                "auto-update" : 1,
-                "mirrors" : [
-                    "https://raw.githubusercontent.com/ugexe/Perl6-ecosystems/master/p6c1.json",
-                    "git://github.com/ugexe/Perl6-ecosystems.git",
-                    "http://ecosystem-api.p6c.org/projects1.json"
-                ]
-            }
-        }
+        ]
     ],
     "Fetch" : [
         {

--- a/t/distribution-depends-parsing.t
+++ b/t/distribution-depends-parsing.t
@@ -166,20 +166,22 @@ my $recommendation-manager = (
     Zef::Repository but role :: {
         method plugins(*@) {
             [
-                class :: does PackageRepository {
-                    method search(*@identities --> Seq) {
-                        gather for @identities -> $as {
-                            take Candidate.new(:dist(Zef::Distribution.new(:name($as))), :$as, :from<Test>)
-                                if $as ∈ <Available AvailableToo>;
-                            take Candidate.new(:dist(Zef::Distribution.new(:name($as), :depends['Unsatisfiable'])), :$as, :from<Test>)
-                                if $as eq 'HasUnsatisfiableDep';
-                            take Candidate.new(:dist(Zef::Distribution.new(:name($as), :depends['HasUnsatisfiableDep'])), :$as, :from<Test>)
-                                if $as eq 'HasTransitivelyUnsatisfiableDep';
-                            take Candidate.new(:dist(Zef::Distribution.new(:name($as), :depends[{:any["AvailableToo", "Available"]},])), :$as, :from<Test>)
-                                if $as eq 'DependsOnAvailableTooOrAvailable';
+                [
+                    class :: does PackageRepository {
+                        method search(*@identities --> Seq) {
+                            gather for @identities -> $as {
+                                take Candidate.new(:dist(Zef::Distribution.new(:name($as))), :$as, :from<Test>)
+                                    if $as ∈ <Available AvailableToo>;
+                                take Candidate.new(:dist(Zef::Distribution.new(:name($as), :depends['Unsatisfiable'])), :$as, :from<Test>)
+                                    if $as eq 'HasUnsatisfiableDep';
+                                take Candidate.new(:dist(Zef::Distribution.new(:name($as), :depends['HasUnsatisfiableDep'])), :$as, :from<Test>)
+                                    if $as eq 'HasTransitivelyUnsatisfiableDep';
+                                take Candidate.new(:dist(Zef::Distribution.new(:name($as), :depends[{:any["AvailableToo", "Available"]},])), :$as, :from<Test>)
+                                    if $as eq 'DependsOnAvailableTooOrAvailable';
+                            }
                         }
-                    }
-                },
+                    },
+                ],
             ]
         }
     }

--- a/t/repository.t
+++ b/t/repository.t
@@ -51,14 +51,14 @@ subtest 'Zef::Repository.candidates' => {
             }
         }
 
-        my $zef-repository = Zef::Repository.new but role :: { method plugins(|--> List) { Mock::Repository::One.new, Mock::Repository::Two.new } };
+        my $zef-repository = Zef::Repository.new but role :: { method plugins(|--> List) { [[Mock::Repository::One.new, Mock::Repository::Two.new],] } };
         my @candidates = $zef-repository.candidates('Foo');
         is @candidates.elems, 1, 'Results are grouped by Candidate.as';
         is @candidates.head.dist.ver, v0.1, 'Results return sorted from highest api/ver to lowest';
 
         # Like the previous test, but switching the order of the plugins
         {
-            temp $zef-repository = Zef::Repository.new but role :: { method plugins(|--> List) { Mock::Repository::Two.new, Mock::Repository::One.new } };
+            temp $zef-repository = Zef::Repository.new but role :: { method plugins(|--> List) { [[Mock::Repository::Two.new, Mock::Repository::One.new],] } };
             is @candidates.head.dist.ver, v0.1, 'Results return sorted from highest api/ver to lowest';
         }
     }

--- a/xt/repository.t
+++ b/xt/repository.t
@@ -31,7 +31,7 @@ subtest 'Repository' => {
         my $mock-repository1 = Mock::Repository.new;
         my $mock-repository2 = Mock::Repository.new;
         my $repository = Zef::Repository.new but role :: {
-            method plugins { state @plugins = $mock-repository1, $mock-repository2; return @plugins; }
+            method plugins { [[$mock-repository1, $mock-repository2],] }
         }
         my @candidates = $repository.search("Mock::Repository");
         is +@candidates, 4;


### PR DESCRIPTION
Currently all ecosystems are given equal considerations when making
a recommendation for a namespace. This change changes the array of
recommendation managers to an array of an array of recommendation
managers. This allows a setup like `[[Darkpan],[fez,p6c]]` where
if `Foo` is found in Darkpan it will always be chosen, even if fez
or p6c have a `Foo` with a higher version.

Note this is incomplete -- some of the deduplication logic currently
in Zef::Client!find-prereq-candidates needs to be moved to Zef::Repository
so if it e.g. only finds 1 of 2 namespaces it queried for that it
searches the next group (and only for the missing namespace).