### PR TITLE
Fix issue when no candidates are found

### DIFF
--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -142,7 +142,7 @@ class Zef::Repository does PackageRepository does Pluggable {
             $storage.search(@search-for, :strict).Slip
         }
 
-        my @unsorted-grouped-candis = @unsorted-candis.categorize({.as}).values;
+        my @unsorted-grouped-candis = @unsorted-candis.grep(*.defined).categorize({.as}).values;
 
         # Take the distribution with the highest version out of all matching distributions from each repository
         my @sorted-candis = @unsorted-grouped-candis.map: -> $candis {


### PR DESCRIPTION
Previously this could give the error No such method 'as' for
invocant of type 'Any' such as when it failed to find a native
dependency that wasn't already installed. This change returns
the original behavior where zef presents a message telling the
user it cannot find the dependency and any suggestions it has.