### PR TITLE
Don't bypass interface by extracting into cache directory

### DIFF
--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -582,7 +582,7 @@ class Zef::Client {
             my $tmp        = $candi.uri.parent;
             my $stage-at   = $candi.uri;
             my $relpath    = $stage-at.relative($tmp);
-            my $extract-to = $!cache.IO.child($relpath);
+            my $extract-to = %!config<TempDir>.IO.child($relpath);
             die "failed to create directory: {$tmp.absolute}"
                 unless ($tmp.IO.e || mkdir($tmp));
 

--- a/lib/Zef/Repository/Ecosystems.rakumod
+++ b/lib/Zef/Repository/Ecosystems.rakumod
@@ -36,7 +36,7 @@ class Zef::Repository::Ecosystems does PackageRepository {
     =head1 Description
 
     A basic C<Repository> that uses a file (containing an array of hash / META6 json) as a database. It is
-    used for the default 'fez', p6c', and 'cpan' ecosystems, and is also a good choice for ad-hoc darkpans
+    used for the default 'fez', 'p6c', and 'cpan' ecosystems, and is also a good choice for ad-hoc darkpans
     by passing it your own mirrors in the config.
 
     =head1 Methods

--- a/lib/Zef/Repository/LocalCache.rakumod
+++ b/lib/Zef/Repository/LocalCache.rakumod
@@ -160,8 +160,10 @@ class Zef::Repository::LocalCache does PackageRepository {
     #| provides it, allowing each Repository to do things like keep a simple list of
     #| identities installed, keep a cache of anything installed (how its used here), etc
     method store(*@dists --> Bool) {
-        for @dists.unique(:as(*.identity)).map(*.IO.parent.IO).unique -> $from {
-            try copy-paths( $from, $.cache.IO.child($from.basename) )
+        for @dists.grep({ not self.search($_.identity).elems }) -> $dist {
+            my $from = $dist.IO;
+            my $to   = $.cache.IO.child($from.basename).child($dist.id);
+            try copy-paths( $from, $to )
         }
         self!update;
     }


### PR DESCRIPTION
When adding distributions to the local cache we previously would
e.g. extract the tar file to $cache-dir. However this can be
problematic because the extractors are not aware of the required
file structure of the $cache-dir. This can lead to consumers of
$cache-dir to do funny thing.

This also adds a check to the cache modules store method so that
it won't try to store something that is already stored in the cache.

Both of the above fix an issue where distributions in a tar archive
without a directory prefix in the archive file would lead to the
cache storing additionally copies of itself within itself.