### PR TITLE
Skip 'update' output table when not using elevated verbosity

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ test_script:
 
     # change path to make sure next `zef` commands aren't using any files in cwd or lib/
     - cd %APPVEYOR_BUILD_FOLDER%\..
-    - zef update
+    - zef update --debug
 
     # test informational commands
     - zef --version
@@ -79,7 +79,7 @@ test_script:
     - raku -I inst#foo -M Distribution::Common::Remote::Github -e ""
 
     - zef --/confirm nuke TempDir StoreDir RootDir
-    - zef update cached # test single repository update; should be 0 after previous nuke
+    - zef update cached --debug # test single repository update; should be 0 after previous nuke
     - raku -I %APPVEYOR_BUILD_FOLDER% %APPVEYOR_BUILD_FOLDER%/bin/zef --/confirm nuke site home
 
 shallow_clone: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ variables:
         raku -I. bin/zef install $PWD
 
         # change path to make sure next `zef` commands aren't using any files in cwd or lib/
-        (cd .. && zef update)
+        (cd .. && zef update --debug)
 
         # test informational commands
         zef --version
@@ -79,7 +79,7 @@ variables:
         raku -I inst#foo -M Distribution::Common::Remote::Github -e ''
 
         zef --/confirm nuke TempDir StoreDir RootDir
-        zef update cached # test single repository update; should be 0 after previous nuke
+        zef update cached --debug # test single repository update; should be 0 after previous nuke
         raku -I /home/circleci/project /home/circleci/project/bin/zef --/confirm nuke site home
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
 
     # change path to make sure next `zef` commands aren't using any files in cwd or lib/
     - cd $TRAVIS_BUILD_DIR/..
-    - zef update
+    - zef update --debug
 
     # test informational commands
     - zef --version
@@ -94,5 +94,5 @@ script:
     - raku -I inst#foo -M Distribution::Common::Remote::Github -e ''
 
     - zef --/confirm nuke TempDir StoreDir RootDir
-    - zef update cached # test single repository update; should be 0 after previous nuke
+    - zef update cached --debug # test single repository update; should be 0 after previous nuke
     - raku -I $TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR/bin/zef --/confirm nuke site home

--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -109,13 +109,6 @@ class Zef::Repository does PackageRepository does Pluggable {
 
     Updates each ecosystem backend (generally downloading a p6c.json or cpan.json file, or updating the 'cached' index).
 
-    Generally you won't care about the return result of this method, and indeed in the future maybe it should be removed. Usually we just want the
-    effects to happen (updating all ecosystem backends), but C<Zef::CLI> currently relies on the return result to show how many distributions are
-    in each ecosystem after updating.
-
-    Returns a C<Hash> where the key is the ecosystem 'name' (as defined in its entry in C<resources/config.json>) and its values are the results
-    of calling C<.available> on that ecosystem (i.e. an C<Array> of C<Candidate>).
-
     =end pod
 
 
@@ -200,15 +193,13 @@ class Zef::Repository does PackageRepository does Pluggable {
     }
 
     #| Update each Repository / backend
-    method update(*@plugins --> Hash) {
+    method update(*@plugins --> Nil) {
         my @can-update = self!plugins(@plugins).grep: -> $plugin {
             note "Plugin '{$plugin.short-name}' does not support `.update` -- Skipping" unless $plugin.can('update'); # UNDO doesn't work here yet
             $plugin.can('update');
         }
 
-        my %updates = @can-update.race(:batch(1)).map({ $_.update; $_.id => $_.available.elems }).hash;
-
-        return %updates;
+        @can-update.race(:batch(1)).map({ $_.update });
     }
 
     #| Like self.plugins this returns a list of plugins that Pluggable + @.backends provides, but also allows

--- a/lib/Zef/Repository/Ecosystems.rakumod
+++ b/lib/Zef/Repository/Ecosystems.rakumod
@@ -36,7 +36,7 @@ class Zef::Repository::Ecosystems does PackageRepository {
     =head1 Description
 
     A basic C<Repository> that uses a file (containing an array of hash / META6 json) as a database. It is
-    used for the default 'fez', p6c', and 'cpan' ecosystems, and is also a good choice for ad-hoc darkpans
+    used for the default 'fez', 'p6c', and 'cpan' ecosystems, and is also a good choice for ad-hoc darkpans
     by passing it your own mirrors in the config.
 
     =head1 Methods


### PR DESCRIPTION
The documentation for Z:R.update stated the return value was likely to be removed in the future, and now it is so. This makes its behavior consistent with the interface for all the Z:R:*.update adapters.

This also makes the table output of `zef update` only occur when using --verbose or --debug. This makes `zef update` take ~2s and `zef update --verbose` take ~20s instead of both taking ~20s. The actual reason its so slow is because there isn't a way to count the number of distributions without creating the distribution objects first (which is hard to avoid since creating the object automatically greps out meta data that isnt valid in certain ways). Since having a low/no output for `zef update` makes sense anyway this can stand in as a workaround in the mean time.