### PR TITLE
Remove usage of $*PERL

### DIFF
--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -1009,9 +1009,7 @@ package Zef::CLI {
 
     #| Detailed version information
     multi sub MAIN(Bool :version($) where .so) {
-        say $*PERL.compiler.version <= v2018.12
-            ?? 'Version detection requires a rakudo newer than v2018.12'
-            !! ($VERSION // 'unknown');
+        say $VERSION // 'unknown';
 
         exit 0;
     }

--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -507,11 +507,7 @@ class Zef::Client {
         return @local-candis;
     }
     method !fetch(*@candidates ($, *@) --> Array[Candidate]) {
-        my $dispatcher := $*PERL.compiler.version < v2018.08
-            ?? @candidates
-            !! @candidates.hyper(:batch(1), :degree($!fetch-degree || 5));
-
-        my Candidate @fetched = $dispatcher.map: -> $candi {
+        my Candidate @fetched = @candidates.hyper(:batch(1), :degree($!fetch-degree || 5)).map: -> $candi {
             self.logger.emit({
                 level   => DEBUG,
                 stage   => FETCH,
@@ -715,11 +711,7 @@ class Zef::Client {
 
     # xxx: needs some love
     method test(*@candidates ($, *@) --> Array[Candidate]) {
-        my $dispatcher := $*PERL.compiler.version < v2018.08
-            ?? @candidates
-            !! @candidates.hyper(:batch(1), :degree($!test-degree || 1));
-
-        my Candidate @tested = $dispatcher.map: -> $candi {
+        my Candidate @tested = @candidates.hyper(:batch(1), :degree($!test-degree || 1)).map: -> $candi {
             self.logger.emit({
                 level   => INFO,
                 stage   => TEST,

--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -134,12 +134,7 @@ class Zef::Repository does PackageRepository does Pluggable {
         my @unsorted-candis = eager gather GROUP: for self!plugins -> @repo-group {
             my @look-for = %searchable.grep(*.value).hash.keys.sort;
 
-            # XXX: Delete this eventually
-            my $dispatchers := $*PERL.compiler.version < v2018.08
-                ?? @repo-group
-                !! @repo-group.hyper(:batch(1)); # a new thread per Repository backend we will search with below
-
-            my @group-results = $dispatchers.map: -> $repo {
+            my @group-results = @repo-group.hyper(:batch(1)).map: -> $repo {
                 my @search-for = $repo.id eq 'Zef::Repository::LocalCache' ?? @identities !! @look-for;
                 $repo.search(@search-for, :strict).Slip;
             }
@@ -179,12 +174,7 @@ class Zef::Repository does PackageRepository does Pluggable {
         my @searchable = @identities.grep({ not $_.starts-with("." | "/") });
 
         my @unsorted-candis = eager gather GROUP: for self!plugins -> @repo-group {
-            # XXX: Delete this eventually
-            my $dispatchers := $*PERL.compiler.version < v2018.08
-                ?? @repo-group
-                !! @repo-group.hyper(:batch(1)); # a new thread per Repository backend we will search with below
-
-            my @group-results = $dispatchers.hyper(:batch(1)).map: -> $repo {
+            my @group-results = @repo-group.hyper(:batch(1)).map: -> $repo {
                 $repo.search(@searchable).Slip;
             }
             if @group-results.elems {

--- a/lib/Zef/Service/FileReporter.rakumod
+++ b/lib/Zef/Service/FileReporter.rakumod
@@ -83,15 +83,15 @@ class Zef::Service::FileReporter does Messenger does Reporter {
                 :bits($*KERNEL.bits),
             }),
             :perl({
-                :name($*PERL.name),
-                :version($*PERL.version.Str),
-                :auth($*PERL.auth),
+                :name($*RAKU.name),
+                :version($*RAKU.version.Str),
+                :auth($*RAKU.auth),
                 :compiler({
-                    :name($*PERL.compiler.name),
-                    :version($*PERL.compiler.version.Str),
-                    :auth($*PERL.compiler.auth),
-                    :release($*PERL.compiler.release),
-                    :codename($*PERL.compiler.codename),
+                    :name($*RAKU.compiler.name),
+                    :version($*RAKU.compiler.version.Str),
+                    :auth($*RAKU.compiler.auth),
+                    :release($*RAKU.compiler.release),
+                    :codename($*RAKU.compiler.codename),
                 }),
             }),
             :vm({

--- a/lib/Zef/Utils/SystemQuery.rakumod
+++ b/lib/Zef/Utils/SystemQuery.rakumod
@@ -105,7 +105,7 @@ module Zef::Utils::SystemQuery {
                     my $query-source = do given $/[0] {
                         when 'distro' { $*DISTRO }
                         when 'kernel' { $*KERNEL }
-                        when 'perl'   { $*PERL   }
+                        when 'perl'   { $*RAKU   }
                         when 'raku'   { $*RAKU   }
                         when 'vm'     { $*VM     }
                     }


### PR DESCRIPTION
$*PERL will be deprecated in a future raku release. This removes usages of $*PERL where its no longer needed, and replaces the remaining usages with $*RAKU