### PR TITLE
Use the cache less often when querying for distributions

### DIFF
--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -161,9 +161,7 @@ class Zef::Repository does PackageRepository does Pluggable {
             my $version   = @presorted.tail.dist.ver;
 
             my @sorted = @presorted.grep({ .dist.ver eq $version }).grep({ .dist.api eq $api });
-
-            # Prefer candidates from Zef::Repository::Local to avoid re-downloading cached items
-            @sorted.sort({ ($^a.from // '') eq 'Zef::Repository::LocalCache' }).tail;
+            @sorted.tail;
         }
 
         # dedupe things the earlier `.as` categorization won't group right, like Foo:ver<1.0+> and Foo:ver<1.1+>

--- a/resources/config.json
+++ b/resources/config.json
@@ -36,12 +36,6 @@
                         "http://360.zef.pm/"
                     ]
                 }
-            },
-            {
-                "short-name" : "cached",
-                "enabled" : 1,
-                "module" : "Zef::Repository::LocalCache",
-                "options" : { }
             }
         ],
         [
@@ -72,6 +66,14 @@
                         "http://ecosystem-api.p6c.org/projects1.json"
                     ]
                 }
+            }
+        ],
+        [
+            {
+                "short-name" : "cached",
+                "enabled" : 1,
+                "module" : "Zef::Repository::LocalCache",
+                "options" : { }
             }
         ]
     ],


### PR DESCRIPTION
Before v0.13.0 when the repositories in the config were not grouped
the cache could easily act as a universal alternative for given
distribution names. Now that ecosystems are grouped it could only
act as an alternative for the ecosystems it is explicitly grouped
with, but doing so also shadows lower tier repos in a way many
users may not expect.

This moves the cache to the very last possible ecosystem to query
from, relegating it to mostly serve as a store of things you may
have downloaded (in case the release/branch disappears or changes)
rather than a means to save bandwidth.