### PR TITLE
Pass logger along to installer

### DIFF
--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -821,7 +821,7 @@ class Zef::Client {
                     }
                 }
 
-                take $candi if $!installer.install($candi, :$cur, :force($!force-install), :timeout($!install-timeout));
+                take $candi if $!installer.install($candi, :$cur, :force($!force-install), :$!logger, :timeout($!install-timeout));
             }
         }
 


### PR DESCRIPTION
This doesn't actually enable anything new, but an installer plugin
should have access to the logger.