### PR TITLE
Support increased verbosity in TAP plugin

### DIFF
--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -302,6 +302,7 @@ package Zef::CLI {
 
     my $verbosity = preprocess-args-verbosity-mutate(@*ARGS);
     %*ENV<ZEF_BUILDPM_DEBUG> = $verbosity >= DEBUG;
+    %*ENV<HARNESS_VERBOSE> = $verbosity >= DEBUG;
     my $CONFIG    = preprocess-args-config-mutate(@*ARGS);
     my $VERSION   = try EVAL q[$?DISTRIBUTION.meta<ver version>.first(*.so)];
 


### PR DESCRIPTION
The previous TAP plugin required capturing $*OUT/$*ERR from TAPs
output which complicated showing that data to the user (such as
prefixing each line with i.e. '[zef] ...'). This uses new changes
to TAP to integrate with stdout and stderr Suppliers, allowing
output to be handled similarly as most other plugins.

This also sets HARNESS_VERBOSITY if --debug is passed which will
e.g. show individual test results and not just the result of
individual files.