### PR TITLE
Also allow < and > in (download) URLs

### DIFF
--- a/lib/Zef/Utils/URI.rakumod
+++ b/lib/Zef/Utils/URI.rakumod
@@ -84,7 +84,7 @@ class Zef::Utils::URI {
         token segment       { <.pchar>* }
         token segment-nz    { <.pchar>+ }
         token segment-nz-nc { [<.unreserved> || <.pct-encoded> || <.sub-delims>]+    }
-        token pchar { <.unreserved> || <.pct-encoded> || <.sub-delims> || ':' || '@' }
+        token pchar { <.unreserved> || <.pct-encoded> || <.sub-delims> || ':' || '@' || '<' || '>' }
         token query       { [<.pchar> || '/' || '?']*           }
         token fragment    { [<.pchar> || '/' || '?']*           }
         token pct-encoded { '%' <.xdigit> <.xdigit>             }


### PR DESCRIPTION
This is needed to get the URLs that the REA uses, to be acceptable by zef