### PR TITLE
Fix regression with not setting cwd for TAP plugin

### DIFF
--- a/lib/Zef/Service/TAP.rakumod
+++ b/lib/Zef/Service/TAP.rakumod
@@ -95,6 +95,9 @@ class Zef::Service::TAP does Tester does Messenger {
 
         my $result = try {
             require ::('TAP');
+            my $cwd = $*CWD;
+            chdir($path);
+            LEAVE chdir($cwd);
             my @incdirs  = $path.absolute, |@includes;
             my @handlers = ::("TAP::Harness::SourceHandler::Raku").new(:@incdirs);
             my $parser   = ::("TAP::Harness").new(:@handlers, :output($.stdout), :err($.stderr));


### PR DESCRIPTION
In the future we will be able to give TAP a cwd, but for now return to using the original chdir code