### PR TITLE
Modernize various references

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,6 @@
 {
     "meta-version"  : "0",
-    "perl"          : "6.c",
+    "raku"          : "6.c",
     "name"          : "zef",
     "api"           : "0",
     "version"       : "0.14.2",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ if both passed all their tests. For example: if module A failed its tests, then 
     zef install "CSV::Parser:ver<0.1.2>"
 
     # PATH
-    zef install ./Perl6-Net--HTTP
+    zef install ./Raku-Net--HTTP
 
     # URL
     zef -v install https://github.com/ugexe/zef.git
@@ -349,11 +349,11 @@ Output the url and launch a browser to open it.
 
     # also opens browser
     $ zef browse Net::HTTP bugtracker
-    https://github.com/ugexe/Perl6-Net--HTTP/issues
+    https://github.com/ugexe/Raku-Net--HTTP/issues
 
     # only outputs the url
     $ zef browse Net::HTTP bugtracker --/open
-    https://github.com/ugexe/Perl6-Net--HTTP/issues
+    https://github.com/ugexe/Raku-Net--HTTP/issues
 
 #### **locate** \[$identity, $name-path, $sha1-id\]
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To install via rakubrew, please use the following command:
     # smoke test modules from all repositories
     zef smoke
 
-    # run Build.pm if one exists in given path
+    # run Build.rakumod if one exists in given path
     zef build .
 
     # update Repository package lists
@@ -313,10 +313,10 @@ Run tests on each distribution located at \[`@paths`\]
 
 #### **build** \[\*@paths\]
 
-Run the Build.pm file located in the given \[`@paths`\]
+Run the Build.rakumod file located in the given \[`@paths`\]
 
 If you want to create a build hook, put the following dependency-free boilerplate
-in a file named `Build.pm` at the root of your distribution:
+in a file named `Build.rakumod` at the root of your distribution:
 
     class Build {
         method build($dist-path) {
@@ -457,7 +457,7 @@ To summarize:
 
 #### Phases / Plugins Settings
 
-These consist of an array of hashes that describe how to instantiate some class that fulfills the appropriate interface from _Zef.pm_ (`Repository` `Fetcher` `Extractor` `Builder` `Tester` `Reporter`)
+These consist of an array of hashes that describe how to instantiate some class that fulfills the appropriate interface from _Zef.rakumod_ (`Repository` `Fetcher` `Extractor` `Builder` `Tester` `Reporter`)
 
 The descriptions follow this format:
 

--- a/README.md
+++ b/README.md
@@ -199,54 +199,47 @@ Upgrade specified identities. If no identities are provided, zef attempts to upg
 
 #### **search** \[$identity\]
 
-How these are handled depends on the `Repository` engine used, which by default is `Zef::Repository::Ecosystems>p6c<`
+How these are handled depends on the `Repository` engine used, which by default is `Zef::Repository::Ecosystems<fez>` and `Zef::Repository::Ecosystems<rea>`
 
     $ zef -v search URI
     ===> Found 4 results
     -------------------------------------------------------------------------
     ID|From                              |Package             |Description
     -------------------------------------------------------------------------
-    1 |Zef::Repository::LocalCache       |URI:ver<0.1.1>    |A URI impleme...
-    2 |Zef::Repository::Ecosystems<p6c>  |URI:ver<0.1.1>    |A URI impleme...
-    3 |Zef::Repository::Ecosystems<cpan> |URI:ver<0.1.1>    |A URI impleme...
-    4 |Zef::Repository::Ecosystems<cpan> |URI:ver<0.000.001>|A URI impleme...
-    -------------------------------------------------------------------------
+    2 |Zef::Repository::Ecosystems<fez> |URI:ver<0.1.1>    |A URI impleme...
+    3 |Zef::Repository::Ecosystems<rea> |URI:ver<0.1.1>    |A URI impleme...
+    4 |Zef::Repository::Ecosystems<rea> |URI:ver<0.000.001>|A URI impleme...
+    ------------------------------------------f-------------------------------
 
 #### **info** \[$identity\]
 
 View meta information of a distribution
 
-    $ zef -v info HTTP::UserAgent
-    - Info for: HTTP::UserAgent
-    - Identity: HTTP::UserAgent:ver<1.1.16>:auth<github:sergot>
-    - Recommended By: Zef::Repository::LocalCache
-    Author:  github:sergot
-    Description:     Web user agent
-    Source-url:      https://github.com/sergot/http-useragent.git
-    Provides: 11 modules
-    #       HTTP::Cookie
-    #       HTTP::Header
-    #       HTTP::Cookies
-    #       HTTP::Message
-    #       HTTP::Request
-    #       HTTP::Response
-    #       HTTP::MediaType
-    #       HTTP::UserAgent
-    #       HTTP::Header::Field
-    #       HTTP::Request::Common
-    #       HTTP::UserAgent::Common
-    Depends: 7 items
-    ---------------------------------
-    ID|Identity           |Installed?
-    ---------------------------------
-    1 |HTTP::Status       |✓
-    2 |File::Temp         |✓
-    3 |DateTime::Parse    |✓
-    4 |Encode             |✓
-    5 |MIME::Base64       |✓
-    6 |URI                |✓
-    7 |IO::Capture::Simple|✓
-    ---------------------------------
+    $ zef info Distribution::Common::Remote -v
+    - Info for: Distribution::Common::Remote
+    - Identity: Distribution::Common::Remote:ver<0.1.0>:auth<github:ugexe>:api<0>
+    - Recommended By: Zef::Repository::Ecosystems<rea>
+    - Installed: No
+    Description:     Create an installable Distribution from common remote sources
+    License:     Artistic-2.0
+    Source-url:  https://raw.githubusercontent.com/raku/REA/main/archive/D/Distribution%3A%3ACommon%3A%3ARemote/Distribution%3A%3ACommon%3A%3ARemote%3Aver%3C0.1.0%3E%3Aauth%3Cgithub%3Augexe%3E.tar.gz
+    Provides: 2 modules
+    ----------------------------------------------------------------------------------
+    Module                              |Path-Name
+    ----------------------------------------------------------------------------------
+    Distribution::IO::Remote::Github    |lib/Distribution/IO/Remote/Github.rakumod
+    Distribution::Common::Remote::Github|lib/Distribution/Common/Remote/Github.rakumod
+    ----------------------------------------------------------------------------------
+    Support:
+    #   bugtracker: https://github.com/ugexe/Raku-Distribution--Common--Remote/issues
+    #   source: https://github.com/ugexe/Raku-Distribution--Common--Remote.git
+    Depends: 2 items
+    ----------------------------------
+    ID|Identity            |Installed?
+    ----------------------------------
+    1 |Distribution::Common|✓
+    2 |Test                |✓
+    ----------------------------------
 
 **Options**
 
@@ -272,9 +265,10 @@ on cpan, but we \*can\* get the $x most recent additions (we use 100 for now).
 
     zef --installed list perl   # Only list modules installed by rakudo itself
 
-    zef list cpan               # Only show available modules from the repository
-    zef list p6c                # with a name field matching the arguments to `list`
-    zef list cached             # (be sure the repository is enabled in config)
+    zef list fez               # Only show available modules from the repository
+    zef list rea               # with a name field matching the arguments to `list`
+    zef list p6c               # (be sure the repository is enabled in config)
+    zef list cpan --cpan       # (or enabled via a cli flag)
 
 Otherwise results from all enabled repositories will be returned.
 
@@ -465,7 +459,7 @@ These consist of an array of hashes that describe how to instantiate some class 
 The descriptions follow this format:
 
     {
-        "short-name" : "p6c",
+        "short-name" : "fez",
         "enabled" : 1,
         "module" : "Zef::Repository::Ecosystems",
         "options" : { }
@@ -475,7 +469,7 @@ and are instantiated via
 
     ::($hash<module>).new(|($hash<options>)
 
-- **short-name** - This adds an enable and disable flag by the same name to the CLI (e.g. `--p6c` and `--/p6c`) and is used when referencing which object took some action.
+- **short-name** - This adds an enable and disable flag by the same name to the CLI (e.g. `--fez` and `--/fez`) and is used when referencing which object took some action.
 - **enabled** - Set to 0 to skip over the object during consideration (it will never be loaded). If omitted or if the value is non 0 then it will be enabled for use.
 - **module** - The name of the class to instantiate. While it doesn't technically have to be a module it _does_ need to be a known namespace to `require`.
 - **options** - These are passed to the objects `new` method and may not be consistent between modules as they are free to implement their own requirements.

--- a/README.md
+++ b/README.md
@@ -313,21 +313,24 @@ Run tests on each distribution located at \[`@paths`\]
 
 #### **build** \[\*@paths\]
 
-Run the Build.rakumod file located in the given \[`@paths`\]
+Run the build step for each distribution located in the given \[`@paths`\]
 
-If you want to create a build hook, put the following dependency-free boilerplate
-in a file named `Build.rakumod` at the root of your distribution:
+Set the env variable **ZEF\_BUILDPM\_DEBUG=1** or use the _--debug_ flag for additional debugging information.
 
+If you want to create a build hook you have two options:
+
+* **PREFERRED** List a builder module that can do what you need in the `builder` field of the META6.json file. For instace many cases of the I-need-to-run-make pattern can list `"builder":"Distribution::Builder::MakeFromJSON"` and supply some extra info to the `"build"` field (a non-standard `Distribution::Builder::MakeFromJSON` specific field). For a more concrete example check out how `Inline::Perl5` [uses the builder field](https://github.com/niner/Inline-Perl5/blob/2e7b99fb03d182d15df4f88818d835b151117786/META6.json#L58-L68). Remember to add any such module to your `build-depends` though! See `Zef::Service::Shell::DistributionBuilder` for more information.
+
+* **DEPRECATED** (_but probably never going away_) Put the following dependency-free boilerplate in a file named `Build.rakumod` at the root of your distribution:
+
+    ```
     class Build {
         method build($dist-path) {
             # do build stuff to your module
             # which is located at $dist-path
         }
     }
-
-Set the env variable **ZEF\_BUILDPM\_DEBUG=1** or use the _--debug_ flag for additional debugging information.
-
-_Note: In the future, a more appropriate hooking solution will replace this._
+    ```
 
 #### **look** \[$identity\]
 

--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -1037,7 +1037,7 @@ package Zef::CLI {
                 uninstall               Uninstall specified distributions
                 test                    Run tests on a given module's path
                 fetch                   Fetch and extract module's source
-                build                   Run the Build.pm in a given module's path
+                build                   Run the Build.rakumod in a given module's path
                 look                    Fetch followed by shelling into the module's path
                 update                  Update package indexes for repositories
                 upgrade (BETA)          Upgrade specific distributions (or all if no arguments)

--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -831,7 +831,7 @@ class Zef::Client {
     method make-install(
         CompUnit::Repository :@to!, # target CompUnit::Repository
         Bool :$fetch = True,        # try fetching whats missing
-        Bool :$build = True,        # run Build.pm (DEPRECATED..?)
+        Bool :$build = True,        # run Build.rakumod (DEPRECATED..?)
         Bool :$test  = True,        # run tests
         Bool :$dry,                 # do everything *but* actually install
         Bool :$serial,

--- a/lib/Zef/Distribution.rakumod
+++ b/lib/Zef/Distribution.rakumod
@@ -21,7 +21,7 @@ class Zef::Distribution does Distribution is Zef::Distribution::DependencySpecif
         my $dist = Zef::Distribution.new(|%meta);
 
         # Show the meta data
-        say $dist.meta.perl;
+        say $dist.meta.raku;
 
         # Output if the $dist contains a namespace matching Foo::Bar:ver<1>
         say $dist.contains-spec("Foo::Bar:ver<1>");

--- a/lib/Zef/Distribution/Local.rakumod
+++ b/lib/Zef/Distribution/Local.rakumod
@@ -18,7 +18,7 @@ class Zef::Distribution::Local is Zef::Distribution {
         my $dist = Zef::Distribution::Local.new($*CWD);
 
         # Show the meta data
-        say $dist.meta.perl;
+        say $dist.meta.raku;
 
         # Output the content of the first item in provides
         with $dist.meta<provides>.hash.values.head -> $name-path {

--- a/lib/Zef/Distribution/Local.rakumod
+++ b/lib/Zef/Distribution/Local.rakumod
@@ -55,7 +55,7 @@ class Zef::Distribution::Local is Zef::Distribution {
         method content($name-path --> IO::Handle:D)
 
     Returns an unopened C<IO::Handle> that can be used to get the content of the C<$name-path>, where C<$name-path>
-    is a value of the distributions C<provides> e.g. C<lib/Foo.pm6>, C<$dist.content($dist.meta<provides>{"Foo"})>.
+    is a value of the distributions C<provides> e.g. C<lib/Foo.rakumod>, C<$dist.content($dist.meta<provides>{"Foo"})>.
 
     =end pod
 

--- a/lib/Zef/Identity.rakumod
+++ b/lib/Zef/Identity.rakumod
@@ -50,7 +50,7 @@ class Zef::Identity {
                 version => ~($ident<ver version>.first(*.defined) // ''),
                 auth    => ~($ident<auth>    // '').trans(['\<', '\>'] => ['<', '>']),
                 api     => ~($ident<api>     // ''),
-                from    => ~($ident<from>    || 'Perl6'),
+                from    => ~($ident<from>    || 'Raku'),
             );
         }
     }
@@ -61,7 +61,7 @@ class Zef::Identity {
             ~ (($!version // '' ) ne ('*' | '')     ?? ":ver<"  ~ $!version ~ ">" !! '')
             ~ (($!auth    // '' ) ne ('*' | '')     ?? ":auth<" ~ $!auth    ~ ">" !! '')
             ~ (($!api     // '' ) ne ('*' | '')     ?? ":api<"  ~ $!api     ~ ">" !! '')
-            ~ (($!from    // '' ) ne ('Perl6' | '') ?? ":from<" ~ $!from    ~ ">" !! '');
+            ~ (($!from    // '' ) ne ('Raku' | 'Perl6' | '') ?? ":from<" ~ $!from    ~ ">" !! '');
     }
 
     method hash {

--- a/lib/Zef/Repository/Ecosystems.rakumod
+++ b/lib/Zef/Repository/Ecosystems.rakumod
@@ -145,9 +145,9 @@ class Zef::Repository::Ecosystems does PackageRepository {
     #| see role Repository in lib/Zef.pm6
     method search(Bool :$strict, *@identities, *%fields --> Array[Candidate]) {
         return Nil unless @identities || %fields;
-
         my %specs = @identities.map: { $_ => Zef::Distribution::DependencySpecification.new($_) }
-        my @searchable-identities = %specs.classify({ .value.from-matcher })<Perl6>.grep(*.defined).hash.keys;
+        my @raku-specs = %specs.classify({ .value.from-matcher })<Raku Perl6>.map(*.Slip);
+        my @searchable-identities = @raku-specs.grep(*.defined).hash.keys;
         return Nil unless @searchable-identities;
 
         # populate %!short-name-lookup

--- a/lib/Zef/Repository/Ecosystems.rakumod
+++ b/lib/Zef/Repository/Ecosystems.rakumod
@@ -92,10 +92,10 @@ class Zef::Repository::Ecosystems does PackageRepository {
     #| Similar to @!distributions, but indexes by short name i.e. { "Foo::Bar" => ($dist1, $dist2), "Baz" => ($dist1) }
     has Array[Distribution] %!short-name-lookup;
 
-    #| see role Repository in lib/Zef.pm6
+    #| see role Repository in lib/Zef.rakumod
     method id(--> Str) { $?CLASS.^name.split('+', 2)[0] ~ "<{$!name}>" }
 
-    #| see role Repository in lib/Zef.pm6
+    #| see role Repository in lib/Zef.rakumod
     method available(--> Array[Candidate]) {
         self!populate-distributions;
 
@@ -113,7 +113,7 @@ class Zef::Repository::Ecosystems does PackageRepository {
     }
 
     #| Iterate over mirrors until we successfully fetch and save one
-    #| see role Repository in lib/Zef.pm6
+    #| see role Repository in lib/Zef.rakumod
     has Int $!update-counter; # Keep track if we already did an update during this runtime
     method update(--> Nil) {
         $!update-counter++;
@@ -142,7 +142,7 @@ class Zef::Repository::Ecosystems does PackageRepository {
         }
     }
 
-    #| see role Repository in lib/Zef.pm6
+    #| see role Repository in lib/Zef.rakumod
     method search(Bool :$strict, *@identities, *%fields --> Array[Candidate]) {
         return Nil unless @identities || %fields;
         my %specs = @identities.map: { $_ => Zef::Distribution::DependencySpecification.new($_) }

--- a/lib/Zef/Repository/LocalCache.rakumod
+++ b/lib/Zef/Repository/LocalCache.rakumod
@@ -129,7 +129,8 @@ class Zef::Repository::LocalCache does PackageRepository {
         return Nil unless @identities || %fields;
 
         my %specs = @identities.map: { $_ => Zef::Distribution::DependencySpecification.new($_) }
-        my @searchable-identities = %specs.classify({ .value.from-matcher })<Perl6>.grep(*.defined).hash.keys;
+        my @raku-specs = %specs.classify({ .value.from-matcher })<Raku Perl6>.map(*.Slip);
+        my @searchable-identities = @raku-specs.grep(*.defined).hash.keys;
         return Nil unless @searchable-identities;
 
         # populate %!short-name-lookup

--- a/lib/Zef/Repository/LocalCache.rakumod
+++ b/lib/Zef/Repository/LocalCache.rakumod
@@ -91,7 +91,7 @@ class Zef::Repository::LocalCache does PackageRepository {
     #| Similar to @!distributions, but indexes by short name i.e. { "Foo::Bar" => ($dist1, $dist2), "Baz" => ($dist1) }
     has Array[Distribution] %!short-name-lookup;
 
-    #| see role Repository in lib/Zef.pm6
+    #| see role Repository in lib/Zef.rakumod
     method available(--> Array[Candidate]) {
         self!populate-distributions;
 
@@ -124,7 +124,7 @@ class Zef::Repository::LocalCache does PackageRepository {
         so $content ?? self!spurt-package-list($content) !! False;
     }
 
-    #| see role Repository in lib/Zef.pm6
+    #| see role Repository in lib/Zef.rakumod
     method search(Bool :$strict, *@identities, *%fields --> Array[Candidate]) {
         return Nil unless @identities || %fields;
 

--- a/t/distribution-depends-parsing.rakutest
+++ b/t/distribution-depends-parsing.rakutest
@@ -8,7 +8,7 @@ use Zef::Distribution;
 
 my $json = q:to/META6/;
     {
-        "perl":"6",
+        "raku":"6.c",
         "name":"Test::Complex::Depends",
         "version":"0",
         "auth":"github:stranger",
@@ -42,7 +42,7 @@ ok any($dist.depends-specs.map(*.from-matcher)) ~~ 'native';
 
 with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $dist {
     {
-        "perl":"6",
+        "raku":"6.c",
         "name":"Test::Complex::Depends",
         "version":"0",
         "auth":"github:stranger",
@@ -73,7 +73,7 @@ with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $
 # mixed depends types
 with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $dist {
     {
-        "perl":"6",
+        "raku":"6.c",
         "name":"Test::Complex::Depends",
         "version":"0",
         "auth":"github:stranger",
@@ -115,7 +115,7 @@ with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $
 
 with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $dist {
     {
-        "perl":"6",
+        "raku":"6.c",
         "name":"Test::Complex::Depends",
         "version":"0",
         "auth":"github:stranger",
@@ -134,7 +134,7 @@ with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $
 
 with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $dist {
     {
-        "perl":"6",
+        "raku":"6.c",
         "name":"Test::Complex::Depends",
         "version":"0",
         "auth":"github:stranger",
@@ -221,7 +221,7 @@ for (
     },
 ) -> $test {
     with Zef::Distribution.new(
-            :perl(6),
+            :raku<6.c>,
             :name<Test::Complex::Depends>,
             :version<0>,
             :auth('github:stranger'),
@@ -257,7 +257,7 @@ subtest 'X::Zef::UnsatisfiableDependency' => {
         ["Available", {:any[{:name<Unavailable>, :from<native>}, {:name<Unavailable2>, :from<native>}]}],
     ) -> $test {
         with Zef::Distribution.new(
-                :perl(6),
+                :raku<6.c>,
                 :name<Test::Complex::Depends>,
                 :version<0>,
                 :auth('github:stranger'),

--- a/t/distribution-depends-parsing.rakutest
+++ b/t/distribution-depends-parsing.rakutest
@@ -36,7 +36,7 @@ my $json = q:to/META6/;
 
 my $dist = Zef::Distribution.new(|Rakudo::Internals::JSON.from-json($json));
 ok any($dist.depends-specs.map(*.name)) ~~ 'Zef::Client';
-ok any($dist.depends-specs.map(*.from-matcher)) ~~ 'Perl6';
+ok any($dist.depends-specs.map(*.from-matcher)) ~~ 'Raku';
 ok any($dist.depends-specs.map(*.name)) ~~ any('mac', 'win', 'linux', 'unknown');
 ok any($dist.depends-specs.map(*.from-matcher)) ~~ 'native';
 
@@ -67,7 +67,7 @@ with Zef::Distribution.new(|Rakudo::Internals::JSON.from-json(q:to/META6/)) -> $
     is $dist.depends-specs.elems, 2;
     ok any($dist.depends-specs.map(*.name)) ~~ any("Foo::Win32_1", "Foo::Linux_1", "Foo::Unknown_1");
     ok any($dist.depends-specs.map(*.name)) ~~ any("Foo::Win32_2", "Foo::Linux_2", "Foo::Unknown_2");
-    ok any($dist.depends-specs.map(*.from-matcher)) ~~ 'Perl6';
+    ok any($dist.depends-specs.map(*.from-matcher)) ~~ 'Raku';
 }
 
 # mixed depends types


### PR DESCRIPTION
This updates various Perl 6 references to use their Raku counterpart, as well as updating a few examples/references to be less out-of-date.