### PR TITLE
Change --help flag to say instead of note

### DIFF
--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -311,7 +311,17 @@ package Zef::CLI {
 
     proto MAIN(|) is export {
         # Suppress backtrace
-        CATCH { default { try { ::("Rakudo::Internals").?LL-EXCEPTION } ?? .rethrow !! .message.&note; &*EXIT(1) } }
+        CATCH { default { try { ::("Rakudo::Internals").?LL-EXCEPTION } ?? .rethrow !! .message.&
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        ; &*EXIT(1) } }
         {*}
     }
 
@@ -1022,7 +1032,7 @@ package Zef::CLI {
     }
 
     multi sub MAIN(Bool :h(:help($))) {
-        note qq:to/END_USAGE/
+        say qq:to/END_USAGE/
             Zef - Raku Module Management
 
             USAGE


### PR DESCRIPTION
Probably this would resolve https://github.com/ugexe/zef/issues/477.

To be honest, it could be that this also redirects the help to stdout when there are legit arguments and --help provided at the same time. You probably know it better; either way, if that happens, I'd still consider it a feature rather than a bug.