### PR TITLE
Pass loggers through functions instead of initializing with object

### DIFF
--- a/lib/Zef.rakumod
+++ b/lib/Zef.rakumod
@@ -11,15 +11,6 @@ package Zef {
     enum STAGE is export <RESOLVE FETCH EXTRACT FILTER BUILD TEST INSTALL REPORT>;
     enum PHASE is export <BEFORE START LIVE STOP AFTER>;
 
-    # A way to avoid printing everything to make --quiet option more universal between plugins
-    # Need to create a messaging format to include the phase, file, verbosity level, progress,
-    # etc we may or may not display as necessary. It's current usage is not finalized and
-    # any suggestions for this are well taken
-    role Messenger  is export {
-        has $.stdout = Supplier.new;
-        has $.stderr = Supplier.new;
-    }
-
     # Get a resource located at a uri and save it to the local disk
     role Fetcher is export {
         method fetch($uri, $save-as) { ... }
@@ -39,12 +30,12 @@ package Zef {
 
     # test a single file OR all the files in a directory (recursive optional)
     role Tester is export {
-        method test($path, :@includes) { ... }
+        method test($path, :@includes, :$stdout, :$stderr) { ... }
         method test-matcher($path) { ... }
     }
 
     role Builder is export {
-        method build($dist, :@includes) { ... }
+        method build($dist, :@includes, :$stdout, :$stderr) { ... }
         method build-matcher($path) { ... }
     }
 

--- a/lib/Zef/Install.rakumod
+++ b/lib/Zef/Install.rakumod
@@ -88,19 +88,24 @@ class Zef::Install does Installer does Pluggable {
         my $installer = self!install-matcher($dist).first(*.so);
         die "No installing backend available" unless ?$installer;
 
+        my $stdout = Supplier.new;
+        my $stderr = Supplier.new;
         if ?$logger {
             $logger.emit({ level => DEBUG, stage => INSTALL, phase => START, candi => $candi, message => "Installing with plugin: {$installer.^name}" });
-            $installer.stdout.Supply.grep(*.defined).act: -> $out { $logger.emit({ level => VERBOSE, stage => INSTALL, phase => LIVE, candi => $candi, message => $out }) }
-            $installer.stderr.Supply.grep(*.defined).act: -> $err { $logger.emit({ level => ERROR,   stage => INSTALL, phase => LIVE, candi => $candi, message => $err }) }
+            $stdout.Supply.grep(*.defined).act: -> $out { $logger.emit({ level => VERBOSE, stage => INSTALL, phase => LIVE, candi => $candi, message => $out }) }
+            $stderr.Supply.grep(*.defined).act: -> $err { $logger.emit({ level => ERROR,   stage => INSTALL, phase => LIVE, candi => $candi, message => $err }) }
         }
 
-        my $todo    = start { $installer.install($dist, :$cur, :$force) };
+        my $todo    = start { $installer.install($dist, :$cur, :$force, :$stdout, :$stderr) };
         my $time-up = ($timeout ?? Promise.in($timeout) !! Promise.new);
         await Promise.anyof: $todo, $time-up;
         $logger.emit({ level => DEBUG, stage => INSTALL, phase => LIVE, candi => $candi, message => "Installing {$dist.path} timed out" })
             if ?$logger && $time-up.so && $todo.not;
 
         my $got = $todo.so ?? $todo.result !! False;
+
+        $stdout.done();
+        $stderr.done();
 
         return $got;
     }

--- a/lib/Zef/Service/FetchPath.rakumod
+++ b/lib/Zef/Service/FetchPath.rakumod
@@ -1,7 +1,7 @@
 use Zef;
 use Zef::Utils::FileSystem;
 
-class Zef::Service::FetchPath does Fetcher does Extractor does Messenger {
+class Zef::Service::FetchPath does Fetcher does Extractor {
 
     =begin pod
 
@@ -70,19 +70,20 @@ class Zef::Service::FetchPath does Fetcher does Extractor does Messenger {
 
     =head2 method fetch
 
-        method fetch(IO() $source-path, IO() $save-to --> IO::Path)
+        method fetch(IO() $source-path, IO() $save-to, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
     Fetches the given C<$source-path> from the file system and copies it to C<$save-to> (+ timestamp if C<$source-path>
-    is a directory) directory.
+    is a directory) directory. A C<Supplier> can be supplied as C<:$stdout> and C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually saved to (usually a subdirectory under the passed-in
     C<$save-to>). On failure it returns C<Nil>.
 
     =head2 method extract
 
-        method extract(IO() $source-path, IO() $save-to --> IO::Path)
+        method extract(IO() $source-path, IO() $save-to, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
-    Extracts the given C<$source-path> from the file system and copies it to C<$save-to>.
+    Extracts the given C<$source-path> from the file system and copies it to C<$save-to>. A C<Supplier> can be
+    supplied as C<:$stdout> and C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually extracted to. On failure it returns C<Nil>.
 
@@ -113,7 +114,7 @@ class Zef::Service::FetchPath does Fetcher does Extractor does Messenger {
     }
 
     #| Fetch (copy) the given source path to the $save-to (+ timestamp if source-path is a directory) directory
-    method fetch(IO() $source-path, IO() $save-to --> IO::Path) {
+    method fetch(IO() $source-path, IO() $save-to, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         return Nil if !$source-path.e;
         return $source-path if $source-path.absolute eq $save-to.absolute; # fakes a fetch
         my $dest-path = $source-path.d ?? $save-to.child("{$source-path.IO.basename}_{time}") !! $save-to;
@@ -125,7 +126,7 @@ class Zef::Service::FetchPath does Fetcher does Extractor does Messenger {
     #| Extract (copy) the files located in $source-path directory to $save-to directory.
     #| This is mostly the same as fetch, and essentially allows the workflow to treat
     #| any uri type (including paths) as if they can be extracted.
-    method extract(IO() $source-path, IO() $save-to --> IO::Path) {
+    method extract(IO() $source-path, IO() $save-to, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         my $extracted-to = $save-to.child($source-path.basename);
         my @extracted = copy-paths($source-path, $extracted-to);
         return +@extracted ?? $extracted-to !! Nil;

--- a/lib/Zef/Service/InstallRakuDistribution.rakumod
+++ b/lib/Zef/Service/InstallRakuDistribution.rakumod
@@ -1,6 +1,6 @@
 use Zef;
 
-class Zef::Service::InstallRakuDistribution does Installer does Messenger {
+class Zef::Service::InstallRakuDistribution does Installer {
 
     =begin pod
 
@@ -17,11 +17,17 @@ class Zef::Service::InstallRakuDistribution does Installer does Messenger {
 
         my $installer = Zef::Service::InstallRakuDistribution.new;
 
+        # Add logging if we want to see output
+        my $stdout = Supplier.new;
+        my $stderr = Supplier.new;
+        $stdout.Supply.tap: { say $_ };
+        $stderr.Supply.tap: { note $_ };
+
         # Assuming our current directory is a raku distribution
         # with no dependencies or all dependencies already installed...
         my $dist-to-install = Zef::Distribution::Local.new($*CWD);
         my $cur = CompUnit::RepositoryRegistry.repository-for-name("site"); # default install location
-        my $passed = so $installer.install($dist-to-test, :$cur);
+        my $passed = so $installer.install($dist-to-test, :$cur, :$stdout, :$stderr);
         say $passed ?? "PASS" !! "FAIL";
 
     =end code
@@ -52,10 +58,11 @@ class Zef::Service::InstallRakuDistribution does Installer does Messenger {
 
     =head2 method install
     
-        method install(Distribution $dist, CompUnit::Repository :$cur, Bool :$force --> Bool:D)
+        method install(Distribution $dist, CompUnit::Repository :$cur, Bool :$force, Supplier $stdout, Suppluer :$stderr --> Bool:D)
 
     Install the distribution C<$dist> to the CompUnit::Repository C<$cur>. If C<$force> is C<True>
-    then it will allow reinstalling an already installed distribution.
+    then it will allow reinstalling an already installed distribution. A C<Supplier> can be supplied
+    as C<:$stdout> and C<:$stderr> to receive any output.
 
     Returns C<True> if the install succeeded.
 
@@ -70,7 +77,7 @@ class Zef::Service::InstallRakuDistribution does Installer does Messenger {
 
     #| Install the distribution in $candi.dist to the $cur CompUnit::Repository.
     #| Use :force to install over an existing distribution using the same name/auth/ver/api
-    method install(Distribution $dist, CompUnit::Repository :$cur, Bool :$force --> Bool:D) {
+    method install(Distribution $dist, CompUnit::Repository :$cur, Bool :$force, Supplier :$stdout, Supplier :$stderr --> Bool:D) {
         $cur.install($dist, :$force);
         return True;
     }

--- a/lib/Zef/Service/Shell/PowerShell/download.rakumod
+++ b/lib/Zef/Service/Shell/PowerShell/download.rakumod
@@ -1,7 +1,7 @@
 use Zef;
 use Zef::Service::Shell::PowerShell;
 
-class Zef::Service::Shell::PowerShell::download is Zef::Service::Shell::PowerShell does Fetcher does Messenger {
+class Zef::Service::Shell::PowerShell::download is Zef::Service::Shell::PowerShell does Fetcher {
 
     =begin pod
 
@@ -55,9 +55,10 @@ class Zef::Service::Shell::PowerShell::download is Zef::Service::Shell::PowerShe
 
     =head2 method fetch
 
-        method fetch(Str() $uri, IO() $save-as --> IO::Path)
+        method fetch(Str() $uri, IO() $save-as, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
     Fetches the given C<$uri> to C<$save-to> via a PowerShell script C<%?RESOURCES{"scripts/win32http.ps1"}>.
+    A C<Supplier> can be supplied as C<:$stdout> and C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually saved to. On failure it returns C<Nil>.
 
@@ -73,7 +74,7 @@ class Zef::Service::Shell::PowerShell::download is Zef::Service::Shell::PowerShe
     }
 
     #| Fetch the given url
-    method fetch(Str() $uri, IO() $save-as --> IO::Path) {
+    method fetch(Str() $uri, IO() $save-as, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         die "target download directory {$save-as.parent} does not exist and could not be created"
             unless $save-as.parent.d || mkdir($save-as.parent);
 

--- a/lib/Zef/Service/Shell/PowerShell/unzip.rakumod
+++ b/lib/Zef/Service/Shell/PowerShell/unzip.rakumod
@@ -1,7 +1,7 @@
 use Zef;
 use Zef::Service::Shell::PowerShell;
 
-class Zef::Service::Shell::PowerShell::unzip is Zef::Service::Shell::PowerShell does Extractor does Messenger {
+class Zef::Service::Shell::PowerShell::unzip is Zef::Service::Shell::PowerShell does Extractor {
 
     =begin pod
 
@@ -31,8 +31,6 @@ class Zef::Service::Shell::PowerShell::unzip is Zef::Service::Shell::PowerShell 
 
     =head1 Description
 
-    C<Extractor> class for handling file based URIs ending in .zip using the C<unzip> command.
-
     C<Extractor> class for handling file based URIs ending in .zip using PowerShell to launch a thin wrapper found
     in C<resources/scripts/win32unzip.ps1>.
 
@@ -58,9 +56,10 @@ class Zef::Service::Shell::PowerShell::unzip is Zef::Service::Shell::PowerShell 
 
     =head2 method extract
 
-        method extract(IO() $archive-file, IO() $extract-to --> IO::Path)
+        method extract(IO() $archive-file, IO() $extract-to, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
     Extracts the files in C<$archive-file> to C<$save-to> via a PowerShell script C<%?RESOURCES{"scripts/win32unzip.ps1"}>.
+    A C<Supplier> can be supplied as C<:$stdout> and C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually extracted to. On failure it returns C<Nil>.
 
@@ -82,7 +81,7 @@ class Zef::Service::Shell::PowerShell::unzip is Zef::Service::Shell::PowerShell 
     }
 
     # Extract the given $archive-file
-    method extract(IO() $archive-file, IO() $extract-to --> IO::Path) {
+    method extract(IO() $archive-file, IO() $extract-to, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         die "archive file does not exist: {$archive-file.absolute}"
             unless $archive-file.e && $archive-file.f;
         die "target extraction directory {$extract-to.absolute} does not exist and could not be created"

--- a/lib/Zef/Service/Shell/Test.rakumod
+++ b/lib/Zef/Service/Shell/Test.rakumod
@@ -1,7 +1,7 @@
 use Zef;
 use Zef::Utils::FileSystem;
 
-class Zef::Service::Shell::Test does Tester does Messenger {
+class Zef::Service::Shell::Test does Tester {
 
     =begin pod
 
@@ -19,14 +19,16 @@ class Zef::Service::Shell::Test does Tester does Messenger {
         my $test = Zef::Service::Shell::Test.new;
 
         # Add logging if we want to see output
-        $test.stdout.Supply.tap: { say $_ };
-        $test.stderr.Supply.tap: { note $_ };
+        my $stdout = Supplier.new;
+        my $stderr = Supplier.new;
+        $stdout.Supply.tap: { say $_ };
+        $stderr.Supply.tap: { note $_ };
 
         # Assuming our current directory is a raku distribution
         # with no dependencies or all dependencies already installed...
         my $dist-to-test = $*CWD;
         my Str @includes = $*CWD.absolute;
-        my $passed = so $test.test($dist-to-test, :@includes);
+        my $passed = so $test.test($dist-to-test, :@includes, :$stdout, :$stderr);
         say $passed ?? "PASS" !! "FAIL";
 
     =end code
@@ -57,10 +59,11 @@ class Zef::Service::Shell::Test does Tester does Messenger {
 
     =head2 method test
 
-        method test(IO() $path, Str :@includes --> Bool:D)
+        method test(IO() $path, Str :@includes, Supplier :$stdout, Supplier :$stderr --> Bool:D)
 
     Test the files ending in C<.rakutest> C<.t6> or C<.t> in the C<t/> directory of the given C<$path> using the
-    provided C<@includes> (e.g. C</foo/bar> or C<inst#/foo/bar>) via the C<prove> command.
+    provided C<@includes> (e.g. C</foo/bar> or C<inst#/foo/bar>) via the C<prove> command. A C<Supplier> can be
+    supplied as C<:$stdout> and C<:$stderr> to receive any output.
 
     Returns C<True> if all test files exited with 0.
 
@@ -74,7 +77,7 @@ class Zef::Service::Shell::Test does Tester does Messenger {
     method test-matcher(Str() $ --> Bool:D) { return True }
 
     #| Test the given paths t/ directory using any provided @includes
-    method test(IO() $path, :@includes --> Bool:D) {
+    method test(IO() $path, :@includes, Supplier :$stdout, Supplier :$stderr --> Bool:D) {
         die "path does not exist: {$path}" unless $path.IO.e;
         my $test-path = $path.child('t');
         return True unless $test-path.e;
@@ -94,8 +97,8 @@ class Zef::Service::Shell::Test does Tester does Messenger {
             my $passed;
             react {
                 my $proc = Zef::zrun-async($*EXECUTABLE.absolute, $rel-test-file);
-                whenever $proc.stdout.lines { $.stdout.emit($_) }
-                whenever $proc.stderr.lines { $.stderr.emit($_) }
+                whenever $proc.stdout.lines { $stdout.emit($_) }
+                whenever $proc.stderr.lines { $stderr.emit($_) }
                 whenever $proc.start(:%ENV, :cwd($path)) { $passed = $_.so }
             }
             $passed;

--- a/lib/Zef/Service/Shell/curl.rakumod
+++ b/lib/Zef/Service/Shell/curl.rakumod
@@ -1,6 +1,6 @@
 use Zef;
 
-class Zef::Service::Shell::curl does Fetcher does Probeable does Messenger {
+class Zef::Service::Shell::curl does Fetcher does Probeable {
 
     =begin pod
 
@@ -53,9 +53,10 @@ class Zef::Service::Shell::curl does Fetcher does Probeable does Messenger {
 
     =head2 method fetch
 
-        method fetch(Str() $uri, IO() $save-as --> IO::Path)
+        method fetch(Str() $uri, IO() $save-as, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
-    Fetches the given C<$uri>, saving it to C<$save-to>.
+    Fetches the given C<$uri>, saving it to C<$save-to>. A C<Supplier> can be supplied as C<:$stdout> and
+    C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually saved to. On failure it returns C<Nil>.
 
@@ -73,7 +74,7 @@ class Zef::Service::Shell::curl does Fetcher does Probeable does Messenger {
     }
 
     #| Fetch the given url
-    method fetch(Str() $uri, IO() $save-as --> IO::Path) {
+    method fetch(Str() $uri, IO() $save-as, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         die "target download directory {$save-as.parent} does not exist and could not be created"
             unless $save-as.parent.d || mkdir($save-as.parent);
 

--- a/lib/Zef/Service/Shell/git.rakumod
+++ b/lib/Zef/Service/Shell/git.rakumod
@@ -1,7 +1,7 @@
 use Zef;
 use Zef::Utils::URI;
 
-class Zef::Service::Shell::git does Fetcher does Extractor does Probeable does Messenger {
+class Zef::Service::Shell::git does Fetcher does Extractor does Probeable {
 
     =begin pod
 
@@ -69,17 +69,19 @@ class Zef::Service::Shell::git does Fetcher does Extractor does Probeable does M
 
     =head2 method fetch
 
-        method fetch(Str() $uri, IO() $save-to --> IO::Path)
+        method fetch(Str() $uri, IO() $save-to, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
     Fetches the given C<$uri> via C<git clone $uri $save-to>, or via C<git pull> if C<$save-to> is an existing git repo.
+    A C<Supplier> can be supplied as C<:$stdout> and C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually saved to. On failure it returns C<Nil>.
 
     =head2 method extract
 
-        method extract(IO() $repo-path, IO() $extract-to)
+        method extract(IO() $repo-path, IO() $extract-to, Supplier :$stdout, Supplier :$stderr)
 
-    Extracts the given C<$repo-path> from the file system to C<$save-to> via C<git checkout ...>.
+    Extracts the given C<$repo-path> from the file system to C<$save-to> via C<git checkout ...>. A C<Supplier> can
+    be supplied as C<:$stdout> and C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually extracted to. On failure it returns C<Nil>.
 
@@ -118,13 +120,13 @@ class Zef::Service::Shell::git does Fetcher does Extractor does Probeable does M
 
     #| Fetch the given url.
     #| First attempts to clone the repository, but if it already exists (or fails) it attempts to pull down new changes
-    method fetch(Str() $uri, IO() $save-as --> IO::Path) {
+    method fetch(Str() $uri, IO() $save-as, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         return self!clone(self!repo-url($uri), $save-as) || self!pull($save-as);
     }
 
     #| Extracts the given path.
     #| For a git repo extraction is equivalent to checking out a specific revision and copying it to separate location
-    method extract(IO() $repo-path, IO() $extract-to) {
+    method extract(IO() $repo-path, IO() $extract-to, Supplier :$stdout, Supplier :$stderr) {
         die "target repo directory {$repo-path.absolute} does not contain a .git/ folder"
             unless $repo-path.child('.git').d;
 

--- a/lib/Zef/Service/Shell/p5tar.rakumod
+++ b/lib/Zef/Service/Shell/p5tar.rakumod
@@ -1,6 +1,6 @@
 use Zef;
 
-class Zef::Service::Shell::p5tar does Extractor does Messenger {
+class Zef::Service::Shell::p5tar does Extractor {
 
     =begin pod
 
@@ -55,9 +55,10 @@ class Zef::Service::Shell::p5tar does Extractor does Messenger {
 
     =head2 method extract
 
-        method extract(IO() $archive-file, IO() $extract-to --> IO::Path)
+        method extract(IO() $archive-file, IO() $extract-to, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
     Extracts the files in C<$archive-file> to C<$save-to> via a Perl script C<%?RESOURCES{"scripts/perl5tar.pl"}>.
+    A C<Supplier> can be supplied as C<:$stdout> and C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually extracted to. On failure it returns C<Nil>.
 
@@ -81,7 +82,7 @@ class Zef::Service::Shell::p5tar does Extractor does Messenger {
     }
 
     #| Extract the given $archive-file
-    method extract(IO() $archive-file, IO() $extract-to --> IO::Path) {
+    method extract(IO() $archive-file, IO() $extract-to, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         die "archive file does not exist: {$archive-file.absolute}"
             unless $archive-file.e && $archive-file.f;
         die "target extraction directory {$extract-to.absolute} does not exist and could not be created"

--- a/lib/Zef/Service/Shell/tar.rakumod
+++ b/lib/Zef/Service/Shell/tar.rakumod
@@ -3,7 +3,7 @@ use Zef;
 # Note: when passing command line arguments to tar in this module be sure to use
 # relative paths. ex: set :cwd to $tar-file.parent, and use $tar-file.basename as the target
 # This is because gnu tar on windows can't handle a windows style volume in path arguments
-class Zef::Service::Shell::tar does Extractor does Messenger {
+class Zef::Service::Shell::tar does Extractor {
 
     =begin pod
 
@@ -57,9 +57,10 @@ class Zef::Service::Shell::tar does Extractor does Messenger {
 
     =head2 method extract
 
-        method extract(IO() $archive-file, IO() $extract-to --> IO::Path)
+        method extract(IO() $archive-file, IO() $extract-to, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
-    Extracts the files in C<$archive-file> to C<$save-to> via the C<tar> command.
+    Extracts the files in C<$archive-file> to C<$save-to> via the C<tar> command. A C<Supplier> can be supplied
+    as C<:$stdout> and C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually extracted to. On failure it returns C<Nil>.
 
@@ -83,7 +84,7 @@ class Zef::Service::Shell::tar does Extractor does Messenger {
     }
 
     #| Extract the given $archive-file
-    method extract(IO() $archive-file, IO() $extract-to --> IO::Path) {
+    method extract(IO() $archive-file, IO() $extract-to, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         die "archive file does not exist: {$archive-file.absolute}"
             unless $archive-file.e && $archive-file.f;
         die "target extraction directory {$extract-to.absolute} does not exist and could not be created"

--- a/lib/Zef/Service/Shell/unzip.rakumod
+++ b/lib/Zef/Service/Shell/unzip.rakumod
@@ -1,6 +1,6 @@
 use Zef;
 
-class Zef::Service::Shell::unzip does Extractor does Messenger {
+class Zef::Service::Shell::unzip does Extractor {
 
     =begin pod
 
@@ -54,9 +54,10 @@ class Zef::Service::Shell::unzip does Extractor does Messenger {
 
     =head2 method extract
 
-        method extract(IO() $archive-file, IO() $extract-to --> IO::Path)
+        method extract(IO() $archive-file, IO() $extract-to, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
-    Extracts the files in C<$archive-file> to C<$save-to> via the C<unzip> command.
+    Extracts the files in C<$archive-file> to C<$save-to> via the C<unzip> command. A C<Supplier> can be supplied
+    as C<:$stdout> and C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually extracted to. On failure it returns C<Nil>.
 
@@ -80,7 +81,7 @@ class Zef::Service::Shell::unzip does Extractor does Messenger {
     }
 
     #| Extract the given $archive-file
-    method extract(IO() $archive-file, IO() $extract-to --> IO::Path) {
+    method extract(IO() $archive-file, IO() $extract-to, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         die "archive file does not exist: {$archive-file.absolute}"
             unless $archive-file.e && $archive-file.f;
         die "target extraction directory {$extract-to.absolute} does not exist and could not be created"

--- a/lib/Zef/Service/Shell/wget.rakumod
+++ b/lib/Zef/Service/Shell/wget.rakumod
@@ -1,6 +1,6 @@
 use Zef;
 
-class Zef::Service::Shell::wget does Fetcher does Probeable does Messenger {
+class Zef::Service::Shell::wget does Fetcher does Probeable {
 
     =begin pod
 
@@ -53,9 +53,10 @@ class Zef::Service::Shell::wget does Fetcher does Probeable does Messenger {
 
     =head2 method fetch
 
-        method fetch(Str() $uri, IO() $save-as --> IO::Path)
+        method fetch(Str() $uri, IO() $save-as, Supplier :$stdout, Supplier :$stderr --> IO::Path)
 
-    Fetches the given C<$uri>, saving it to C<$save-to>.
+    Fetches the given C<$uri>, saving it to C<$save-to>. A C<Supplier> can be supplied as C<:$stdout> and
+    C<:$stderr> to receive any output.
 
     On success it returns the C<IO::Path> where the data was actually saved to. On failure it returns C<Nil>.
 
@@ -73,7 +74,7 @@ class Zef::Service::Shell::wget does Fetcher does Probeable does Messenger {
     }
 
     #| Fetch the given url
-    method fetch(Str() $uri, IO() $save-as --> IO::Path) {
+    method fetch(Str() $uri, IO() $save-as, Supplier :$stdout, Supplier :$stderr --> IO::Path) {
         die "target download directory {$save-as.parent} does not exist and could not be created"
             unless $save-as.parent.d || mkdir($save-as.parent);
 


### PR DESCRIPTION
At one time the various plugins would be created anew for each use, but later on we started caching those instances. That change led to Supply reuse that showed itself as duplicate messages on any use of said plugin beyond the first.

This passes in the loggers through the function calls such that we can create new ones before we call the function. This avoids the Supply reuse issue mentioned earlier.

Fixes #496