### PR TITLE
Remove unneeded EVAL

### DIFF
--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -304,7 +304,7 @@ package Zef::CLI {
     %*ENV<ZEF_BUILDPM_DEBUG> = $verbosity >= DEBUG;
     %*ENV<HARNESS_VERBOSE> = $verbosity >= DEBUG;
     my $CONFIG    = preprocess-args-config-mutate(@*ARGS);
-    my $VERSION   = try EVAL q[$?DISTRIBUTION.meta<ver version>.first(*.so)];
+    my $VERSION   = BEGIN $?DISTRIBUTION.meta<version>;
 
     # TODO: deprecate usage of --depsonly
     @*ARGS = @*ARGS.map: { $_ eq '--depsonly' ?? '--deps-only' !! $_ }


### PR DESCRIPTION
This was useful when $?DISTRIBUTION was first added to rakudo so zef could start using it despite people on older rakudos using newer zef releases. We don't really need to support those old rakudos anymore, so this removes the EVAL.