### PR TITLE
Deprecate --depsonly

### DIFF
--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -306,8 +306,15 @@ package Zef::CLI {
     my $CONFIG    = preprocess-args-config-mutate(@*ARGS);
     my $VERSION   = try EVAL q[$?DISTRIBUTION.meta<ver version>.first(*.so)];
 
-    # TODO: deprecate usage of --depsonly
-    @*ARGS = @*ARGS.map: { $_ eq '--depsonly' ?? '--deps-only' !! $_ }
+    @*ARGS = eager gather for @*ARGS -> $arg {
+        if $arg eq '--depsonly' {
+            note 'DEPRECATED: --depsonly is deprecated, please use --deps-only instead';
+            take '--deps-only'
+        }
+        else {
+            take $arg
+        }
+    }
 
     proto MAIN(|) is export {
         # Suppress backtrace


### PR DESCRIPTION
The command has been advertised as --deps-only for a long time, so start telling users to use that instead of --depsonly.