### PR TITLE
Make probe methods thread safe

### DIFF
--- a/lib/Zef/Service/Shell/curl.rakumod
+++ b/lib/Zef/Service/Shell/curl.rakumod
@@ -62,10 +62,16 @@ class Zef::Service::Shell::curl does Fetcher does Probeable {
 
     =end pod
 
+    my Lock $probe-lock = Lock.new;
+    my Bool $probe-cache;
 
     #| Return true if the `curl` command is available to use
     method probe(--> Bool:D) {
-        state $probe = try { Zef::zrun('curl', '--help', :!out, :!err).so };
+        $probe-lock.protect: {
+            return $probe-cache if $probe-cache.defined;
+            my $probe is default(False) = try so Zef::zrun('curl', '--help', :!out, :!err);
+            return $probe-cache = $probe;
+        }
     }
 
     #| Return true if this Fetcher understands the given uri/path

--- a/lib/Zef/Service/Shell/tar.rakumod
+++ b/lib/Zef/Service/Shell/tar.rakumod
@@ -72,10 +72,16 @@ class Zef::Service::Shell::tar does Extractor {
 
     =end pod
 
+    my Lock $probe-lock = Lock.new;
+    my Bool $probe-cache;
 
     #| Return true if the `tar` command is available to use
     method probe(--> Bool:D) {
-        state $probe = try { Zef::zrun('tar', '--help', :!out, :!err).so };
+        $probe-lock.protect: {
+            return $probe-cache if $probe-cache.defined;
+            my $probe is default(False) = try so Zef::zrun('tar', '--help', :!out, :!err);
+            return $probe-cache = $probe;
+        }
     }
 
     #| Return true if this Extractor understands the given uri/path

--- a/lib/Zef/Service/Shell/unzip.rakumod
+++ b/lib/Zef/Service/Shell/unzip.rakumod
@@ -69,10 +69,16 @@ class Zef::Service::Shell::unzip does Extractor {
 
     =end pod
 
+    my Lock $probe-lock = Lock.new;
+    my Bool $probe-cache;
 
     #| Return true if the `unzip` command is available to use
     method probe(--> Bool:D) {
-        state $probe = try { Zef::zrun('unzip', '--help', :!out, :!err).so };
+        $probe-lock.protect: {
+            return $probe-cache if $probe-cache.defined;
+            my $probe is default(False) = try so Zef::zrun('unzip', '--help', :!out, :!err);
+            return $probe-cache = $probe;
+        }
     }
 
     #| Return true if this Fetcher understands the given uri/path

--- a/lib/Zef/Service/Shell/wget.rakumod
+++ b/lib/Zef/Service/Shell/wget.rakumod
@@ -62,10 +62,16 @@ class Zef::Service::Shell::wget does Fetcher does Probeable {
 
     =end pod
 
+    my Lock $probe-lock = Lock.new;
+    my Bool $probe-cache;
 
     #} Return true if the `wget` command is available to use
     method probe(--> Bool:D) {
-        state $probe = try { Zef::zrun('wget', '--help', :!out, :!err).so };
+        $probe-lock.protect: {
+            return $probe-cache if $probe-cache.defined;
+            my $probe is default(False) = try so Zef::zrun('wget', '--help', :!out, :!err);
+            return $probe-cache = $probe;
+        }
     }
 
     #| Return true if this Fetcher understands the given uri/path

--- a/lib/Zef/Service/TAP.rakumod
+++ b/lib/Zef/Service/TAP.rakumod
@@ -69,10 +69,16 @@ class Zef::Service::TAP does Tester {
 
     =end pod
 
+    my Lock $probe-lock = Lock.new;
+    my Bool $probe-cache;
 
     #| Return true if the `TAP` raku module is available
     method probe(--> Bool:D) {
-        state $probe = self!has-correct-tap-version && (try require ::('TAP')) !~~ Nil ?? True !! False;
+        $probe-lock.protect: {
+            return $probe-cache if $probe-cache.defined;
+            my $probe = self!has-correct-tap-version && (try require ::('TAP')) !~~ Nil;
+            return $probe-cache = $probe;
+        }
     }
 
     method !has-correct-tap-version(--> Bool:D) {


### PR DESCRIPTION
Previously various probe methods used `state`, which is not thread safe. Since we preload all the plugins it didn't need to be thread safe. This updates various probe methods to be thread safe despite the above comment only because it is technically more correct and potentially makes updating the plugin system a bit easier.