### PR TITLE
Avoid permission issues with sharing $*TMPDIR with other users

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ install:
     - '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64'
 
     # Workaround for path length errors during precompilation of longer repo names
-    - SET TMPDIR=C:\tmp
+    - SET ZEF_CONFIG_TEMPDIR=C:\tmp
     - cd C:\
     - md tmp
 

--- a/lib/Zef/Config.rakumod
+++ b/lib/Zef/Config.rakumod
@@ -8,6 +8,8 @@ module Zef::Config {
             if $node.key.ends-with('Dir') {
                 %config{$node.key} = $node.value.subst(/'{$*HOME}' || '$*HOME'/, $*HOME // $*TMPDIR, :g);
                 %config{$node.key} = $node.value.subst(/'{$*TMPDIR}' || '$*TMPDIR'/, $*TMPDIR, :g);
+                %config{$node.key} = $node.value.subst(/'{$*PID}' || '$*PID'/, $*PID, :g);
+                %config{$node.key} = $node.value.subst(/'{time}'/, time, :g);
             }
 
             with %*ENV{sprintf 'ZEF_CONFIG_%s', $node.key.uc} {

--- a/resources/config.json
+++ b/resources/config.json
@@ -1,7 +1,7 @@
 {
     "ConfigVersion" : "1",
     "StoreDir" : "$*HOME/.zef/store",
-    "TempDir"  : "$*TMPDIR/.zef",
+    "TempDir"  : "$*TMPDIR/.zef/{time}.{$*PID}",
     "DefaultCUR" : ["auto"],
     "License" : {
         "whitelist" : "*",


### PR DESCRIPTION
At one point we moved the temp directory zef used from `$*HOME/.zef/tmp` to `$*TMPDIR/.zef`. However, this meant the temp directories started to be the same for different users, and thus permissions issues could arise. This changes the temp directory to `$*TMPDIR/.zef/$time.$pid`, and adds the config logic for interpolating `{time}` and `$*PID`.

Fixes #510