### PR TITLE
Add IRC details

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -60,6 +60,7 @@
     ],
     "support" : {
         "bugtracker" : "https://github.com/ugexe/zef/issues",
+        "irc"        : "ircs://irc.libera.chat:6697/raku-zef",
         "source"     : "https://github.com/ugexe/zef.git"
     },
     "tags"        : [


### PR DESCRIPTION
This adds the new zef IRC channel to it's META6.json support information.