### PR TITLE
Remove extra call to tar during probe

### DIFF
--- a/lib/Zef/Service/Shell/tar.rakumod
+++ b/lib/Zef/Service/Shell/tar.rakumod
@@ -83,7 +83,7 @@ class Zef::Service::Shell::tar does Extractor {
         $probe-lock.protect: {
             return $probe-cache if $probe-cache.defined;
             my $proc = Zef::zrun('tar', '--help', :out, :!err);
-            my $probe is default(False) = try so Zef::zrun('tar', '--help', :out, :!err);
+            my $probe is default(False) = try so $proc;
             @extract-matcher-extensions.push('.zip') if $proc.out.slurp(:close).contains('bsdtar');
             return $probe-cache = $probe;
         }


### PR DESCRIPTION
We only need to call out to tar once, but it looks like it started doing it twice accidently during a refactor. This fixes the probe to only call out to `tar --help` once.