### PR TITLE
Unpin core dependencies

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,8 +8,8 @@
     "description"   : "Raku Module Management",
     "license"       : "Artistic-2.0",
     "build-depends" : [ ],
-    "test-depends"  : [ "Test:ver<6.c+>" ],
-    "depends"       : [ "NativeCall:ver<6.c+>" ],
+    "test-depends"  : [ "Test" ],
+    "depends"       : [ "NativeCall" ],
     "provides"      : {
         "Zef"           : "lib/Zef.rakumod",
         "Zef::Build"    : "lib/Zef/Build.rakumod",

--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -1068,7 +1068,7 @@ class Zef::Client {
         my $lib = "'$spec.name()'";
         $lib = "$lib, v$spec.ver()" if $spec.ver;
         try {
-            EVAL qq[use NativeCall:ver<6.c+>; sub native_library_is_installed is native($lib) \{ !!! \}; native_library_is_installed(); ];
+            EVAL qq[use NativeCall; sub native_library_is_installed is native($lib) \{ !!! \}; native_library_is_installed(); ];
             CATCH { default { return False if .payload.starts-with("Cannot locate native library") } }
         }
         return True;

--- a/t/00-load.rakutest
+++ b/t/00-load.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 2;
 
 subtest 'Core' => {

--- a/t/build.rakutest
+++ b/t/build.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 1;
 
 use Zef;

--- a/t/distribution-depends-parsing.rakutest
+++ b/t/distribution-depends-parsing.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 35;
 
 use Zef;

--- a/t/extract.rakutest
+++ b/t/extract.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 1;
 
 use Zef;

--- a/t/fetch.rakutest
+++ b/t/fetch.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 1;
 
 use Zef;

--- a/t/identity.rakutest
+++ b/t/identity.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 6;
 
 use Zef::Identity;

--- a/t/install.rakutest
+++ b/t/install.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 1;
 
 use Zef;

--- a/t/repository.rakutest
+++ b/t/repository.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 1;
 
 use Zef;

--- a/t/test.rakutest
+++ b/t/test.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 1;
 
 use Zef;

--- a/t/utils-filesystem.rakutest
+++ b/t/utils-filesystem.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 4;
 
 use Zef::Utils::FileSystem;

--- a/xt/install.rakutest
+++ b/xt/install.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 3;
 
 use Zef;

--- a/xt/repository.rakutest
+++ b/xt/repository.rakutest
@@ -1,4 +1,4 @@
-use Test:ver<6.c+>;
+use Test;
 plan 5;
 
 use Zef;


### PR DESCRIPTION
The core modules are no longer versions as e.g. 6.d, so checking for 6.c+ no longer makes sense. We could technically pin it on the 20XX.XX.X type versions rakudo is using, but that will require more consideration by myself (other compilers may not version them similarly, although they would have had to follow the original v6.c versioning), and commitment to a consistent versioning schema by Rakudo for its core modules.