### PR TITLE
Ensure Zef modules all load the same version

### DIFF
--- a/lib/Zef.rakumod
+++ b/lib/Zef.rakumod
@@ -149,8 +149,15 @@ module Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth(
         }
 
         method !try-load(Hash $plugin) {
-            my $module = $plugin<module>;
-            DEBUG($plugin, "Checking: {$module}");
+            use Zef::Identity:auth(Zef.^auth):api(Zef.^api):ver(Zef.^ver);
+            my $identity        = Zef::Identity.new($plugin<module>);
+            my $short-name      = $identity.name;
+            my $plugin-is-core  = so $?DISTRIBUTION.meta<provides>{$short-name}.?chars;
+            my $auth-matcher    = $identity.auth    || do { $plugin-is-core ?? Zef.^auth !! True };
+            my $api-matcher     = $identity.api     || do { $plugin-is-core ?? Zef.^api  !! True };
+            my $version-matcher = $identity.version || do { $plugin-is-core ?? Zef.^ver  !! True };
+            my $dep-spec        = CompUnit::DependencySpecification.new(:$short-name, :$auth-matcher, :$api-matcher, :$version-matcher);
+            DEBUG($plugin, "Checking: {$short-name}");
 
             # default to enabled unless `"enabled" : 0`
             if $plugin<enabled>:exists && (!$plugin<enabled> || $plugin<enabled> eq "0") {
@@ -158,15 +165,15 @@ module Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth(
                 return;
             }
 
-            if (try require ::($module)) ~~ Nil {
+            unless try $*REPO.need($dep-spec) {
                 DEBUG($plugin, "\t(SKIP) Plugin could not be loaded");
                 return;
             }
 
             DEBUG($plugin, "\t(OK) Plugin loaded successful");
 
-            if ::($module).^find_method('probe') {
-                unless ::($module).probe {
+            if ::($short-name).^find_method('probe') {
+                unless ::($short-name).probe {
                     DEBUG($plugin, "\t(SKIP) Probing failed");
                     return;
                 }
@@ -175,19 +182,19 @@ module Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth(
 
             # add attribute `short-name` here to make filtering by name slightly easier
             # until a more elegant solution can be integrated into plugins themselves
-            my $class = ::($module).new(|($plugin<options> // []))\
+            my $class = ::($short-name).new(|($plugin<options> // []))\
                 but role :: { has $.short-name = $plugin<short-name> // '' };
 
             # make the class name more human readable for cli output,
             # i.e. Zef::Service::Shell::curl instead of Zef::Service::Shell::curl+{<anon|1>}
-            $class.^set_name($module);
+            $class.^set_name($short-name);
 
             unless ?$class {
                 DEBUG($plugin, "(SKIP) Plugin unusable: initialization failure");
                 return;
             }
 
-            DEBUG($plugin, "(OK) Plugin is now usable: {$module}");
+            DEBUG($plugin, "(OK) Plugin is now usable: {$short-name}");
             return $class;
         }
     }

--- a/lib/Zef.rakumod
+++ b/lib/Zef.rakumod
@@ -1,4 +1,4 @@
-package Zef {
+module Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>) {
     our sub zrun(*@_, *%_) is export { run (|@_).grep(*.?chars), |%_ }
     our sub zrun-async(*@_, *%_) is export { Proc::Async.new( (|@_).grep(*.?chars), |%_ ) }
 

--- a/lib/Zef/Build.rakumod
+++ b/lib/Zef/Build.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Distribution;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Build does Builder does Pluggable {
 

--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -1,10 +1,10 @@
-use Zef;
-use Zef::Client;
-use Zef::Config;
-use Zef::Utils::FileSystem;
-use Zef::Identity;
-use Zef::Distribution;
-use Zef::Utils::URI :internals;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Client:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Config:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Identity:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Utils::URI:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth) :internals;
 use nqp;
 
 package Zef::CLI {

--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -1,16 +1,15 @@
-use Zef;
-use Zef::Distribution;
-use Zef::Distribution::Local;
-use Zef::Distribution::DependencySpecification;
-use Zef::Repository;
-use Zef::Utils::FileSystem;
-
-use Zef::Fetch;
-use Zef::Extract;
-use Zef::Build;
-use Zef::Test;
-use Zef::Install;
-use Zef::Report;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Repository:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Fetch:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Extract:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Build:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Test:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Install:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Report:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Client {
 

--- a/lib/Zef/Config.rakumod
+++ b/lib/Zef/Config.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 module Zef::Config {
     our sub parse-file($path) {

--- a/lib/Zef/Distribution.rakumod
+++ b/lib/Zef/Distribution.rakumod
@@ -1,6 +1,6 @@
-use Zef;
-use Zef::Distribution::DependencySpecification;
-use Zef::Utils::SystemQuery;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Utils::SystemQuery:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Distribution does Distribution is Zef::Distribution::DependencySpecification {
 

--- a/lib/Zef/Distribution/DependencySpecification.rakumod
+++ b/lib/Zef/Distribution/DependencySpecification.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Identity;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Identity:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 role DependencySpecification {
     method name(--> Str) { ... }

--- a/lib/Zef/Distribution/Local.rakumod
+++ b/lib/Zef/Distribution/Local.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Distribution;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Distribution::Local is Zef::Distribution {
 

--- a/lib/Zef/Extract.rakumod
+++ b/lib/Zef/Extract.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Utils::FileSystem;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Extract does Extractor does Pluggable {
 

--- a/lib/Zef/Fetch.rakumod
+++ b/lib/Zef/Fetch.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Utils::FileSystem;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Fetch does Fetcher does Pluggable {
 

--- a/lib/Zef/Install.rakumod
+++ b/lib/Zef/Install.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Distribution;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Install does Installer does Pluggable {
 

--- a/lib/Zef/Report.rakumod
+++ b/lib/Zef/Report.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 class Zef::Report does Pluggable does Reporter {
 

--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 class Zef::Repository does PackageRepository does Pluggable {
 

--- a/lib/Zef/Repository/Ecosystems.rakumod
+++ b/lib/Zef/Repository/Ecosystems.rakumod
@@ -1,7 +1,7 @@
-use Zef;
-use Zef::Utils::FileSystem;
-use Zef::Distribution;
-use Zef::Distribution::DependencySpecification;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Repository::Ecosystems does PackageRepository {
 

--- a/lib/Zef/Repository/LocalCache.rakumod
+++ b/lib/Zef/Repository/LocalCache.rakumod
@@ -1,7 +1,7 @@
-use Zef;
-use Zef::Distribution::Local;
-use Zef::Distribution::DependencySpecification;
-use Zef::Utils::FileSystem;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Repository::LocalCache does PackageRepository {
 

--- a/lib/Zef/Service/FetchPath.rakumod
+++ b/lib/Zef/Service/FetchPath.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Utils::FileSystem;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::FetchPath does Fetcher does Extractor {
 

--- a/lib/Zef/Service/FileReporter.rakumod
+++ b/lib/Zef/Service/FileReporter.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 class Zef::Service::FileReporter does Reporter {
 

--- a/lib/Zef/Service/InstallRakuDistribution.rakumod
+++ b/lib/Zef/Service/InstallRakuDistribution.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 class Zef::Service::InstallRakuDistribution does Installer {
 

--- a/lib/Zef/Service/Shell/DistributionBuilder.rakumod
+++ b/lib/Zef/Service/Shell/DistributionBuilder.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Distribution::Local;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::Shell::DistributionBuilder does Builder {
 

--- a/lib/Zef/Service/Shell/LegacyBuild.rakumod
+++ b/lib/Zef/Service/Shell/LegacyBuild.rakumod
@@ -1,5 +1,6 @@
-use Zef;
-use Zef::Distribution::Local;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
+
 
 class Zef::Service::Shell::LegacyBuild does Builder {
 

--- a/lib/Zef/Service/Shell/Test.rakumod
+++ b/lib/Zef/Service/Shell/Test.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Utils::FileSystem;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::Shell::Test does Tester {
 

--- a/lib/Zef/Service/Shell/curl.rakumod
+++ b/lib/Zef/Service/Shell/curl.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 class Zef::Service::Shell::curl does Fetcher does Probeable {
 

--- a/lib/Zef/Service/Shell/git.rakumod
+++ b/lib/Zef/Service/Shell/git.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Utils::URI :internals;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Utils::URI:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth) :internals;
 
 class Zef::Service::Shell::git does Fetcher does Extractor does Probeable {
 

--- a/lib/Zef/Service/Shell/prove.rakumod
+++ b/lib/Zef/Service/Shell/prove.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 class Zef::Service::Shell::prove does Tester {
 

--- a/lib/Zef/Service/Shell/tar.rakumod
+++ b/lib/Zef/Service/Shell/tar.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 # Note: when passing command line arguments to tar in this module be sure to use relative
 # paths. ex: set :cwd to $archive-file.parent, and use $archive-file.basename as the target

--- a/lib/Zef/Service/Shell/unzip.rakumod
+++ b/lib/Zef/Service/Shell/unzip.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 class Zef::Service::Shell::unzip does Extractor {
 

--- a/lib/Zef/Service/Shell/wget.rakumod
+++ b/lib/Zef/Service/Shell/wget.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 class Zef::Service::Shell::wget does Fetcher does Probeable {
 

--- a/lib/Zef/Service/TAP.rakumod
+++ b/lib/Zef/Service/TAP.rakumod
@@ -1,5 +1,5 @@
-use Zef;
-use Zef::Utils::FileSystem;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::TAP does Tester {
 

--- a/lib/Zef/Test.rakumod
+++ b/lib/Zef/Test.rakumod
@@ -1,4 +1,4 @@
-use Zef;
+use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
 
 class Zef::Test does Tester does Pluggable {
 


### PR DESCRIPTION
This ensures that when a zef module is loaded that it only imports other zef modules contained with the same distribution.

Note this implementation is a bit verbose and may not be worth cargo culting. There is a PR to rakudo that tries to do this same thing automatically for all distributions (although it needs to be revisited), and the pinning of `auth` is questionable (and may go away in the future). For now we'll see how well doing it the explicit way works out.