### PR TITLE
Avoid printing to stdout/stderr inside repository

### DIFF
--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -1216,17 +1216,22 @@ package Zef::CLI {
         };
 
         with %_<update> {
+            my $stdout = Supplier.new;
+            my $stderr = Supplier.new;
+            $stdout.Supply.act: -> $out { $logger.emit({ level => VERBOSE, stage => RESOLVE, phase => LIVE, message => $out }) }
+            $stderr.Supply.act: -> $err { $logger.emit({ level => ERROR, stage => RESOLVE, phase => LIVE, message => $err }) }
+
             my @plugins = $client.recommendation-manager.plugins.map(*.Slip).grep(*.defined);
 
             if %_<update> === Bool::False {
                 @plugins.map({ try .auto-update = False });
             }
             elsif %_<update> === Bool::True {
-                @plugins.race(:batch(1)).map(*.?update);
+                @plugins.race(:batch(1)).map(*.?update(:$stdout, :$stderr));
             }
             else {
                 @plugins.grep({.short-name ~~ any(%_<update>.grep(*.not))}).map({ try .auto-update = False });
-                @plugins.grep({.short-name ~~ any(%_<update>.grep(*.so))}).race(:batch(1)).map(*.?update);
+                @plugins.grep({.short-name ~~ any(%_<update>.grep(*.so))}).race(:batch(1)).map(*.?update(:$stdout, :$stderr));
             }
         }
 


### PR DESCRIPTION
All other parts of zef send output to stdout/stderr through a logging mechanism. The Repository (and Repository plugins) were the only plugins that were not already doing this. This updates the aforementioned Repository related code to using the idiomatic logging mechanism to send terminal output (specifically the output to tell the user when an ecosystem has been updated).