### PR TITLE
Add staging to installation workflow

### DIFF
--- a/lib/Zef.rakumod
+++ b/lib/Zef.rakumod
@@ -8,7 +8,11 @@ module Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth(
     our sub to-json(|c) { ::("Rakudo::Internals::JSON").to-json(|c) }
 
     enum LEVEL is export <FATAL ERROR WARN INFO VERBOSE DEBUG TRACE>;
-    enum STAGE is export <RESOLVE FETCH EXTRACT FILTER BUILD TEST INSTALL REPORT>;
+
+    # We have an entry called STAGING because STAGE was already taken by the enum. We
+    # should improve this situation in the future.
+    enum STAGE is export <RESOLVE FETCH EXTRACT FILTER BUILD STAGING TEST INSTALL REPORT>;
+
     enum PHASE is export <BEFORE START LIVE STOP AFTER>;
 
     # Get a resource located at a uri and save it to the local disk

--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -353,6 +353,12 @@ package Zef::CLI {
         my $client     = get-client(:config($CONFIG), :$force-test, :$test-timeout, :$test-degree);
         my @candidates = $client.link-candidates( @paths.map(*.&path2candidate) );
         abort "Failed to resolve any candidates. No reason to proceed" unless +@candidates;
+
+        # We don't use CURS for `zef test .` yet, so add the CURFS path of the dist to the includes.
+        for @candidates {
+            $_.dist.metainfo<includes>.prepend($_.dist.path);
+        }
+
         my @tested = $client.test(@candidates);
         my (:@test-pass, :@test-fail) := @tested.classify: {.test-results.grep(*.so) ?? <test-pass> !! <test-fail> }
 

--- a/lib/Zef/Service/Shell/Test.rakumod
+++ b/lib/Zef/Service/Shell/Test.rakumod
@@ -90,9 +90,8 @@ class Zef::Service::Shell::Test does Tester {
 
         my @results = @rel-test-files.map: -> $rel-test-file {
             my %ENV = %*ENV;
-            my @cur-lib  = %ENV<RAKULIB>.?chars ?? %ENV<RAKULIB>.split($*DISTRO.cur-sep) !! ();
-            my @new-lib  = $path.absolute, |@includes;
-            %ENV<RAKULIB> = (|@new-lib, |@cur-lib).join($*DISTRO.cur-sep);
+            my @cur-lib = %ENV<RAKULIB>.?chars ?? %ENV<RAKULIB>.split($*DISTRO.cur-sep) !! ();
+            %ENV<RAKULIB> = (|@includes, |@cur-lib).join($*DISTRO.cur-sep);
 
             my $passed;
             react {

--- a/lib/Zef/Service/Shell/prove.rakumod
+++ b/lib/Zef/Service/Shell/prove.rakumod
@@ -121,9 +121,8 @@ class Zef::Service::Shell::prove does Tester {
         my Str $test-path-cwd      = $path.absolute;
 
         my %ENV = %*ENV;
-        my @cur-lib  = %ENV<RAKULIB>.?chars ?? %ENV<RAKULIB>.split($*DISTRO.cur-sep) !! ();
-        my @new-lib  = $path.absolute, |@includes;
-        %ENV<RAKULIB> = (|@new-lib, |@cur-lib).join($*DISTRO.cur-sep);
+        my @cur-lib = %ENV<RAKULIB>.?chars ?? %ENV<RAKULIB>.split($*DISTRO.cur-sep) !! ();
+        %ENV<RAKULIB> = (|@includes, |@cur-lib).join($*DISTRO.cur-sep);
 
         my @args =
             '--ext', '.rakutest',

--- a/lib/Zef/Service/TAP.rakumod
+++ b/lib/Zef/Service/TAP.rakumod
@@ -104,7 +104,7 @@ class Zef::Service::TAP does Tester {
 
         my $result = try {
             require ::('TAP');
-            my @incdirs  = $path.absolute, |@includes;
+            my @incdirs  = @includes;
             my @handlers = ::("TAP::Harness::SourceHandler::Raku").new(:@incdirs);
             my $parser   = ::("TAP::Harness").new(:@handlers);
             my $promise  = $parser.run(


### PR DESCRIPTION
Previously we always installed to a CURI. However, installing to a CURS means we can test + install while only compiling once. It isn't perfect though, as it doesn't work quite right with custom repository locations. This adds said staging workflow for installing to the default named repos.