### PR TITLE
Allow installing local archive files

### DIFF
--- a/lib/Zef/Extract.rakumod
+++ b/lib/Zef/Extract.rakumod
@@ -163,7 +163,7 @@ class Zef::Extract does Extractor does Pluggable {
         my $path       := $candi.uri;
         my $extractors := self!extractors($path);
         my $name-paths := $extractors.map(*.ls-files($path)).first(*.defined).map(*.IO);
-        my @files       = $name-paths.map({ .is-absolute ?? $path.child(.relative($path)).cleanup.relative($path) !! $_ });
+        my @files       = $name-paths.map({ .is-absolute ?? $path.IO.child(.relative($path)).cleanup.relative($path) !! $_ });
 
         my Str @results = @files.map(*.Str);
         return @results;

--- a/resources/config.json
+++ b/resources/config.json
@@ -126,10 +126,6 @@
             "module" : "Zef::Service::Shell::unzip"
         },
         {
-            "short-name" : "psunzip",
-            "module" : "Zef::Service::Shell::PowerShell::unzip"
-        },
-        {
             "short-name" : "path",
             "module" : "Zef::Service::FetchPath",
             "comment" : "if this goes before git then git wont be able to extract/checkout local paths because this reaches it first :("

--- a/resources/config.json
+++ b/resources/config.json
@@ -118,11 +118,6 @@
             "comment" : "used to checkout (extract) specific tags/sha1/commit/branch from a git repo"
         },
         {
-            "short-name" : "path",
-            "module" : "Zef::Service::FetchPath",
-            "comment" : "if this goes before git then git wont be able to extract/checkout local paths because this reaches it first :("
-        },
-        {
             "short-name" : "tar",
             "module" : "Zef::Service::Shell::tar"
         },
@@ -133,6 +128,11 @@
         {
             "short-name" : "psunzip",
             "module" : "Zef::Service::Shell::PowerShell::unzip"
+        },
+        {
+            "short-name" : "path",
+            "module" : "Zef::Service::FetchPath",
+            "comment" : "if this goes before git then git wont be able to extract/checkout local paths because this reaches it first :("
         }
     ],
     "Build" : [


### PR DESCRIPTION
Previously one could install a local distribution given it was already extracted into a folder, i.e. `zef install ./foo`. This allows installing from local archive files as well, i.e. `zef install ./foo.tar.gz`.