### PR TITLE
Use fallback versions in import statements

### DIFF
--- a/lib/Zef.rakumod
+++ b/lib/Zef.rakumod
@@ -1,4 +1,4 @@
-module Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '') {
+module Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '') {
     our sub zrun(*@_, *%_) is export { run (|@_).grep(*.?chars), |%_ }
     our sub zrun-async(*@_, *%_) is export { Proc::Async.new( (|@_).grep(*.?chars), |%_ ) }
 

--- a/lib/Zef.rakumod
+++ b/lib/Zef.rakumod
@@ -1,4 +1,4 @@
-module Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>) {
+module Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '') {
     our sub zrun(*@_, *%_) is export { run (|@_).grep(*.?chars), |%_ }
     our sub zrun-async(*@_, *%_) is export { Proc::Async.new( (|@_).grep(*.?chars), |%_ ) }
 

--- a/lib/Zef/Build.rakumod
+++ b/lib/Zef/Build.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Build does Builder does Pluggable {

--- a/lib/Zef/Build.rakumod
+++ b/lib/Zef/Build.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Build does Builder does Pluggable {

--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Client:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Config:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Client:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Config:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Config.rakumod
+++ b/lib/Zef/Config.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 module Zef::Config {
     our sub parse-file($path) {

--- a/lib/Zef/Config.rakumod
+++ b/lib/Zef/Config.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 module Zef::Config {
     our sub parse-file($path) {

--- a/lib/Zef/Distribution.rakumod
+++ b/lib/Zef/Distribution.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Utils::SystemQuery:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Distribution.rakumod
+++ b/lib/Zef/Distribution.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Utils::SystemQuery:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Distribution/DependencySpecification.rakumod
+++ b/lib/Zef/Distribution/DependencySpecification.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Identity:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 role DependencySpecification {

--- a/lib/Zef/Distribution/DependencySpecification.rakumod
+++ b/lib/Zef/Distribution/DependencySpecification.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Identity:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 role DependencySpecification {

--- a/lib/Zef/Distribution/Local.rakumod
+++ b/lib/Zef/Distribution/Local.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Distribution::Local is Zef::Distribution {

--- a/lib/Zef/Distribution/Local.rakumod
+++ b/lib/Zef/Distribution/Local.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Distribution::Local is Zef::Distribution {

--- a/lib/Zef/Extract.rakumod
+++ b/lib/Zef/Extract.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Extract does Extractor does Pluggable {

--- a/lib/Zef/Extract.rakumod
+++ b/lib/Zef/Extract.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Extract does Extractor does Pluggable {

--- a/lib/Zef/Fetch.rakumod
+++ b/lib/Zef/Fetch.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Fetch does Fetcher does Pluggable {

--- a/lib/Zef/Fetch.rakumod
+++ b/lib/Zef/Fetch.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Fetch does Fetcher does Pluggable {

--- a/lib/Zef/Install.rakumod
+++ b/lib/Zef/Install.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Install does Installer does Pluggable {

--- a/lib/Zef/Install.rakumod
+++ b/lib/Zef/Install.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Install does Installer does Pluggable {

--- a/lib/Zef/Report.rakumod
+++ b/lib/Zef/Report.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Report does Pluggable does Reporter {
 

--- a/lib/Zef/Report.rakumod
+++ b/lib/Zef/Report.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Report does Pluggable does Reporter {
 

--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Repository does PackageRepository does Pluggable {
 

--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Repository does PackageRepository does Pluggable {
 

--- a/lib/Zef/Repository/Ecosystems.rakumod
+++ b/lib/Zef/Repository/Ecosystems.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Repository/Ecosystems.rakumod
+++ b/lib/Zef/Repository/Ecosystems.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Repository/LocalCache.rakumod
+++ b/lib/Zef/Repository/LocalCache.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Repository/LocalCache.rakumod
+++ b/lib/Zef/Repository/LocalCache.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Service/FetchPath.rakumod
+++ b/lib/Zef/Service/FetchPath.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::FetchPath does Fetcher does Extractor {

--- a/lib/Zef/Service/FetchPath.rakumod
+++ b/lib/Zef/Service/FetchPath.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::FetchPath does Fetcher does Extractor {

--- a/lib/Zef/Service/FileReporter.rakumod
+++ b/lib/Zef/Service/FileReporter.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::FileReporter does Reporter {
 

--- a/lib/Zef/Service/FileReporter.rakumod
+++ b/lib/Zef/Service/FileReporter.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::FileReporter does Reporter {
 

--- a/lib/Zef/Service/InstallRakuDistribution.rakumod
+++ b/lib/Zef/Service/InstallRakuDistribution.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::InstallRakuDistribution does Installer {
 

--- a/lib/Zef/Service/InstallRakuDistribution.rakumod
+++ b/lib/Zef/Service/InstallRakuDistribution.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::InstallRakuDistribution does Installer {
 

--- a/lib/Zef/Service/Shell/DistributionBuilder.rakumod
+++ b/lib/Zef/Service/Shell/DistributionBuilder.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::Shell::DistributionBuilder does Builder {

--- a/lib/Zef/Service/Shell/DistributionBuilder.rakumod
+++ b/lib/Zef/Service/Shell/DistributionBuilder.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::Shell::DistributionBuilder does Builder {

--- a/lib/Zef/Service/Shell/LegacyBuild.rakumod
+++ b/lib/Zef/Service/Shell/LegacyBuild.rakumod
@@ -1,6 +1,5 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
-
 
 class Zef::Service::Shell::LegacyBuild does Builder {
 

--- a/lib/Zef/Service/Shell/LegacyBuild.rakumod
+++ b/lib/Zef/Service/Shell/LegacyBuild.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 

--- a/lib/Zef/Service/Shell/Test.rakumod
+++ b/lib/Zef/Service/Shell/Test.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::Shell::Test does Tester {

--- a/lib/Zef/Service/Shell/Test.rakumod
+++ b/lib/Zef/Service/Shell/Test.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::Shell::Test does Tester {

--- a/lib/Zef/Service/Shell/curl.rakumod
+++ b/lib/Zef/Service/Shell/curl.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::curl does Fetcher does Probeable {
 

--- a/lib/Zef/Service/Shell/curl.rakumod
+++ b/lib/Zef/Service/Shell/curl.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::curl does Fetcher does Probeable {
 

--- a/lib/Zef/Service/Shell/git.rakumod
+++ b/lib/Zef/Service/Shell/git.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::URI:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth) :internals;
 
 class Zef::Service::Shell::git does Fetcher does Extractor does Probeable {

--- a/lib/Zef/Service/Shell/git.rakumod
+++ b/lib/Zef/Service/Shell/git.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::URI:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth) :internals;
 
 class Zef::Service::Shell::git does Fetcher does Extractor does Probeable {

--- a/lib/Zef/Service/Shell/prove.rakumod
+++ b/lib/Zef/Service/Shell/prove.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::prove does Tester {
 

--- a/lib/Zef/Service/Shell/prove.rakumod
+++ b/lib/Zef/Service/Shell/prove.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::prove does Tester {
 

--- a/lib/Zef/Service/Shell/tar.rakumod
+++ b/lib/Zef/Service/Shell/tar.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 # Note: when passing command line arguments to tar in this module be sure to use relative
 # paths. ex: set :cwd to $archive-file.parent, and use $archive-file.basename as the target

--- a/lib/Zef/Service/Shell/tar.rakumod
+++ b/lib/Zef/Service/Shell/tar.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 # Note: when passing command line arguments to tar in this module be sure to use relative
 # paths. ex: set :cwd to $archive-file.parent, and use $archive-file.basename as the target

--- a/lib/Zef/Service/Shell/unzip.rakumod
+++ b/lib/Zef/Service/Shell/unzip.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::unzip does Extractor {
 

--- a/lib/Zef/Service/Shell/unzip.rakumod
+++ b/lib/Zef/Service/Shell/unzip.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::unzip does Extractor {
 

--- a/lib/Zef/Service/Shell/wget.rakumod
+++ b/lib/Zef/Service/Shell/wget.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::wget does Fetcher does Probeable {
 

--- a/lib/Zef/Service/Shell/wget.rakumod
+++ b/lib/Zef/Service/Shell/wget.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::wget does Fetcher does Probeable {
 

--- a/lib/Zef/Service/TAP.rakumod
+++ b/lib/Zef/Service/TAP.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::TAP does Tester {

--- a/lib/Zef/Service/TAP.rakumod
+++ b/lib/Zef/Service/TAP.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 
 class Zef::Service::TAP does Tester {

--- a/lib/Zef/Test.rakumod
+++ b/lib/Zef/Test.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Test does Tester does Pluggable {
 

--- a/lib/Zef/Test.rakumod
+++ b/lib/Zef/Test.rakumod
@@ -1,4 +1,4 @@
-use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
+use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Test does Tester does Pluggable {
 


### PR DESCRIPTION
Zef tries to only load code from the version it was packaged with by doing `use Zef:ver($?DISTRIBUTION.meta<version>)`. However, some `CompUnit::Repository::Registry` return a `Distribution` that only has a `ver` (not `version`) field which would result in `use Zef:ver<>` which isn't a legal import statement. The adds a fallback to the `ver` field, as well as explicitly adding the Raku defaults for all import adverbs.