### PR TITLE
Avoid warnings when ecosystem contains invalid distribution name

### DIFF
--- a/lib/Zef/Repository/Ecosystems.rakumod
+++ b/lib/Zef/Repository/Ecosystems.rakumod
@@ -229,6 +229,9 @@ class Zef::Repository::Ecosystems does PackageRepository {
 
             for self!slurp-package-list -> $meta {
                 with try Zef::Distribution.new(|%($meta)) -> $dist {
+                    # If the distribution doesn't have a name or we can't parse the name then just skip it.
+                    next unless $dist.name;
+
                     # Keep track of out namespaces we are going to index later
                     my @short-names-to-index;
 
@@ -247,7 +250,7 @@ class Zef::Repository::Ecosystems does PackageRepository {
 
                     # Index the short name to the distribution. Make sure entries are
                     # unique since dist name and one module name will usually match.
-                    push %!short-name-lookup{$_}, $dist for @short-names-to-index.unique;
+                    push %!short-name-lookup{$_}, $dist for @short-names-to-index.grep(*.so).unique;
 
                     push @!distributions, $dist;
                 }

--- a/lib/Zef/Repository/LocalCache.rakumod
+++ b/lib/Zef/Repository/LocalCache.rakumod
@@ -207,6 +207,9 @@ class Zef::Repository::LocalCache does PackageRepository {
 
             for self!slurp-package-list -> $path {
                 with try Zef::Distribution::Local.new($!cache.add($path)) -> $dist {
+                    # If the distribution doesn't have a name or we can't parse the name then just skip it.
+                    next unless $dist.name;
+
                     # Keep track of out namespaces we are going to index later
                     my @short-names-to-index;
 
@@ -225,7 +228,7 @@ class Zef::Repository::LocalCache does PackageRepository {
 
                     # Index the short name to the distribution. Make sure entries are
                     # unique since dist name and one module name will usually match.
-                    push %!short-name-lookup{$_}, $dist for @short-names-to-index.unique;
+                    push %!short-name-lookup{$_}, $dist for @short-names-to-index.grep(*.so).unique;
 
                     push @!distributions, $dist;
                 }


### PR DESCRIPTION
Previously it was possible (although extremely unlikely) that a distribution could exist in an ecosystem without a name field, which could lead to warnings when we attempt to stringify it. A similar thing could also occur when an invalid long name is used in the provides field, such that we fail to parse the name. This ignores such distributions during the indexing process.

Fixes #543