### PR TITLE
Fix tar detection and usage on OpenBSD

### DIFF
--- a/lib/Zef/Service/Shell/tar.rakumod
+++ b/lib/Zef/Service/Shell/tar.rakumod
@@ -139,7 +139,7 @@ class Zef::Service::Shell::tar does Extractor {
         react {
             my $cwd := $archive-file.parent;
             my $ENV := %*ENV;
-            my $proc = Zef::zrun-async('tar', '-t', '-f', $archive-file.basename);
+            my $proc = Zef::zrun-async('tar', '-zt', '-f', $archive-file.basename);
             whenever $proc.stdout(:bin) { $output.append($_) }
             whenever $proc.stderr(:bin) { }
             whenever $proc.start(:$ENV, :$cwd) { $passed = $_.so }


### PR DESCRIPTION
This address two issues with `Zef::Service::Shell::tar` on OpenBSD.

The first is detecting tar in the first place.

Previously zef tried to detect tar on OpenBSD by looking for some magic words in the output of `tar`, since there's no `--help` or `--version` option.
    
Currently (as of OpenBSD 7.4) running bare `tar` doesn't produce any of those magic words, so detection fails -- this is true back until at least OpenBSD 6.8.
    
This patch changes the detection to run `tar -cf -`, which will exit silently with code 0 if tar is runnable.

The second issue is a missing `-z` in `ls-files`; GNU tar will list a gzipped tar without complaint using just `-t -f`; OpenBSD tar will not and requires the `-z` option. Adding this mirrors usage in `extract`.