### PR TITLE
Add --/precompile-install flag

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,7 +36,9 @@ test_script:
     # test zef test
     - raku -I. bin/zef --debug --raku-test  test .
 
-    # run relative local path test + install
+    # run relative local path test + install + disable precompilation
+    # (we also test --/precompile-install in other ci tests here, but
+    # it doesn't seem to work right on appveyor)
     - raku -I. bin/zef --debug install .
 
     # test uninstall

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ variables:
         # test zef test
         raku -I. bin/zef --debug test .
 
-        # run relative local path test + install
-        raku -I. bin/zef --debug install .
+        # run relative local path test + install + disable precompilation
+        raku -I. bin/zef --debug --/precompile-install install .
 
         # test uninstall
         raku -I. bin/zef uninstall zef

--- a/README.md
+++ b/README.md
@@ -127,12 +127,15 @@ to fulfill any dependencies of other requested identities.
     --test-timeout=3600
     --install-timeout=3600
 
+    # or set the default to all unset --*-timeout flags to 0
+    --timeout=0
+
     # Number of simultaneous distributions/jobs to process for the corresponding phases
     --fetch-degree=5
     --test-degree=1
 
-    # or set the default to all unset --*-timeout flags to 0
-    --timeout=0
+    # Disable precompilation during installation
+    --/precompile-install
 
     # Do everything except the actual installations
     --dry

--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -123,6 +123,7 @@ package Zef::CLI {
             Int  :$degree,
             Int  :$fetch-degree   = %*ENV<ZEF_FETCH_DEGREE> || $degree || 5, # default different from Zef::Client
             Int  :$test-degree    = %*ENV<ZEF_TEST_DEGREE>  || $degree || 1,
+            Bool :$precompile-install,
             Bool :$dry,
             Bool :$upgrade,# Not Yet Implemented
             Bool :$deps-only,
@@ -175,6 +176,8 @@ package Zef::CLI {
     If C<$fetch-degree> is set zef will download up to that many distributions in parallel.
 
     If C<$test-degree> is set zef will test up to that many distributions in parallel.
+
+    If C<$precompile-install> is set to C<False> then Raku code won't be precompiled during installation.
 
     If C<$dry> is set to C<True> then the final step of actually installing the distribution will be skipped and considered a success.
 
@@ -414,6 +417,7 @@ package Zef::CLI {
         Int  :$degree,
         Int  :$fetch-degree   = %*ENV<ZEF_FETCH_DEGREE> || $degree || 5, # default different from Zef::Client
         Int  :$test-degree    = %*ENV<ZEF_TEST_DEGREE>  || $degree || 1,
+        Bool :$precompile-install = True,
         Bool :$dry,
         Bool :$upgrade,
         Bool :$deps-only,
@@ -441,7 +445,7 @@ package Zef::CLI {
             :$force-build,    :$force-test,      :$force-install,
             :$fetch-timeout,  :$extract-timeout, :$build-timeout,
             :$test-timeout,   :$install-timeout, :$fetch-degree,
-            :$test-degree,
+            :$test-degree,    :$precompile-install,
         );
 
         my CompUnit::Repository @at = $install-to.map(*.&str2cur);
@@ -595,6 +599,7 @@ package Zef::CLI {
         Int  :$degree,
         Int  :$fetch-degree   = %*ENV<ZEF_FETCH_DEGREE> || $degree || 5, # default different from Zef::Client,
         Int  :$test-degree    = %*ENV<ZEF_TEST_DEGREE>  || $degree || 1,
+        Bool :$precompile-install = True,
         Bool :$dry,
         Bool :$update,
         Bool :$serial,
@@ -613,7 +618,7 @@ package Zef::CLI {
             :$force-build,    :$force-test,      :$force-install,
             :$fetch-timeout,  :$extract-timeout, :$build-timeout,
             :$test-timeout,   :$install-timeout, :$fetch-degree,
-            :$test-degree
+            :$test-degree,    :$precompile-install,
         );
 
         my @missing = @identities.grep: { not $client.is-installed($_) };
@@ -656,6 +661,7 @@ package Zef::CLI {
             :$test-timeout,
             :$fetch-degree,
             :$test-degree,
+            :$precompile-install,
             :$dry,
             :$serial,
         );
@@ -936,6 +942,7 @@ package Zef::CLI {
         Int  :$degree,
         Int  :$fetch-degree   = %*ENV<ZEF_FETCH_DEGREE> || $degree || 5, # default different from Zef::Client,
         Int  :$test-degree    = %*ENV<ZEF_TEST_DEGREE>  || $degree || 1,
+        Bool :$precompile-install,
         Bool :$update,
         Bool :$upgrade,
         Bool :$dry,
@@ -950,7 +957,7 @@ package Zef::CLI {
             :$force-build,    :$force-test,      :$force-install,
             :$fetch-timeout,  :$extract-timeout, :$build-timeout,
             :$test-timeout,   :$install-timeout, :$fetch-degree,
-            :$test-degree,
+            :$test-degree,    :$precompile-install,
         );
 
         my @identities = $client.list-available.map(*.dist.identity).unique;
@@ -979,6 +986,7 @@ package Zef::CLI {
             :$test-timeout,
             :$fetch-degree,
             :$test-degree,
+            :$precompile-install,
             :$dry,
             :$serial,
         );
@@ -1080,6 +1088,8 @@ package Zef::CLI {
                 --config-path=[path]    Load a specific Zef config file
                 --[phase]-timeout=[int] Set a timeout (in seconds) for the corresponding phase ( phase: fetch, extract, build, test, install )
                 --[phase]-degree=[int]  Number of simultaneous distributions/jobs to process for the corresponding phase ( phase : fetch, test )
+
+                --/precompile-install   Skip precompiling during installation
 
                 --update                Force a refresh for all module indexes
                 --update=[ecosystem]    Force a refresh for a specific ecosystem module index

--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -316,6 +316,9 @@ class Zef::Client {
     #| If test time dependencies should be considered when building distributions
     has Bool $.test-depends is rw = True;
 
+    #| If precompilation should occur during the installation stage
+    has Bool $.precompile-install is rw = True;
+
     submethod TWEAK(
         :$!cache                  = %!config<StoreDir>.IO,
         :$!fetcher                = Zef::Fetch.new(:backends(|%!config<Fetch>)),
@@ -807,7 +810,7 @@ class Zef::Client {
                     }
                 }
 
-                take $candi if $!installer.install($candi, :$cur, :force($!force-install), :$!logger, :timeout($!install-timeout));
+                take $candi if $!installer.install($candi, :$cur, :force($!force-install), :precompile($!precompile-install), :$!logger, :timeout($!install-timeout));
             }
         }
 
@@ -1084,7 +1087,7 @@ class Zef::Client {
                 });
                 my Str @includes = $staging-repo.path-spec;
                 $_.dist.metainfo<includes> = @includes;
-                $staging-repo.install($_.dist);
+                $staging-repo.install($_.dist, :precompile($!precompile-install));
                 self.logger.emit({
                     level   => INFO,
                     stage   => STAGING,

--- a/lib/Zef/Install.rakumod
+++ b/lib/Zef/Install.rakumod
@@ -50,10 +50,10 @@ class Zef::Install does Installer does Pluggable {
 
     =head2 method install
 
-        method install(Candidate $candi, CompUnit::Repository :$cur!, Bool :$force, Supplier :$logger, Int :$timeout --> Bool:D)
+        method install(Candidate $candi, CompUnit::Repository :$cur!, Bool :$force, Bool :$precompile, Supplier :$logger, Int :$timeout --> Bool:D)
 
     Installs the distribution C<$candi.dist> to C<$cur> (see synopsis). Set C<$force> to C<True> to allow installing a distribution
-    that is already installed.
+    that is already installed. If C<$precompile> is C<False> then it will not precompile during installation.
 
     An optional C<:$logger> can be supplied to receive events about what is occurring.
 
@@ -83,7 +83,7 @@ class Zef::Install does Installer does Pluggable {
 
     #| Install the distribution in $candi.dist to the $cur CompUnit::Repository.
     #| Use :force to install over an existing distribution using the same name/auth/ver/api
-    method install(Candidate $candi, CompUnit::Repository :$cur!, Bool :$force, Supplier :$logger, Int :$timeout --> Bool:D) {
+    method install(Candidate $candi, CompUnit::Repository :$cur!, Bool :$force, Bool :$precompile, Supplier :$logger, Int :$timeout --> Bool:D) {
         my $dist      = $candi.dist;
         my $installer = self!install-matcher($dist).first(*.so);
         die "No installing backend available" unless ?$installer;

--- a/lib/Zef/Service/InstallRakuDistribution.rakumod
+++ b/lib/Zef/Service/InstallRakuDistribution.rakumod
@@ -58,11 +58,12 @@ class Zef::Service::InstallRakuDistribution does Installer {
 
     =head2 method install
     
-        method install(Distribution $dist, CompUnit::Repository :$cur, Bool :$force, Supplier $stdout, Suppluer :$stderr --> Bool:D)
+        method install(Distribution $dist, CompUnit::Repository :$cur, Bool :$force, Bool :$precompile, Supplier $stdout, Suppluer :$stderr --> Bool:D)
 
     Install the distribution C<$dist> to the CompUnit::Repository C<$cur>. If C<$force> is C<True>
-    then it will allow reinstalling an already installed distribution. A C<Supplier> can be supplied
-    as C<:$stdout> and C<:$stderr> to receive any output.
+    then it will allow reinstalling an already installed distribution. If C<$precompile> is C<False>
+    then it will not precompile during installation. A C<Supplier> can be supplied as C<:$stdout>
+    and C<:$stderr> to receive any output.
 
     Returns C<True> if the install succeeded.
 
@@ -77,8 +78,8 @@ class Zef::Service::InstallRakuDistribution does Installer {
 
     #| Install the distribution in $candi.dist to the $cur CompUnit::Repository.
     #| Use :force to install over an existing distribution using the same name/auth/ver/api
-    method install(Distribution $dist, CompUnit::Repository :$cur, Bool :$force, Supplier :$stdout, Supplier :$stderr --> Bool:D) {
-        $cur.install($dist, :$force);
+    method install(Distribution $dist, CompUnit::Repository :$cur, Bool :$force, Bool :$precompile, Supplier :$stdout, Supplier :$stderr --> Bool:D) {
+        $cur.install($dist, :$precompile, :$force);
         return True;
     }
 }


### PR DESCRIPTION
This adds a flag to disable precompilation done when installing to a CompUnit::Repository::Installation

Resolves #547