### PR TITLE
Fix dry installs not staging properly

### DIFF
--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -1075,7 +1075,7 @@ class Zef::Client {
             my @built-candidates = ?$build ?? self.build(@_) !! @_;
             die "No installable candidates remain after `build` failures" unless +@built-candidates;
 
-            my @staged-candidates = ?$dry ?? @built-candidates !! @built-candidates.map({
+            my @staged-candidates = @built-candidates.map({
                 self.logger.emit({
                     level   => INFO,
                     stage   => STAGING,


### PR DESCRIPTION
This fixes a bug in the staging workflow that caused --dry to always exist unsuccessfully.