### PR TITLE
Normalize config path template variables

### DIFF
--- a/lib/Zef/Config.rakumod
+++ b/lib/Zef/Config.rakumod
@@ -4,10 +4,13 @@ module Zef::Config {
     our sub parse-file($path) {
         my %config = %(Zef::from-json( $path.IO.slurp ));
 
+        my $homedir = $*HOME.IO.absolute;
+        my $tempdir = $*TMPDIR.IO.absolute;
+
         for %config -> $node {
             if $node.key.ends-with('Dir') {
-                %config{$node.key} = $node.value.subst(/'{$*HOME}' || '$*HOME'/, $*HOME // $*TMPDIR, :g);
-                %config{$node.key} = $node.value.subst(/'{$*TMPDIR}' || '$*TMPDIR'/, $*TMPDIR, :g);
+                %config{$node.key} = $node.value.subst(/'{$*HOME}' || '$*HOME'/, $homedir // $tempdir, :g);
+                %config{$node.key} = $node.value.subst(/'{$*TMPDIR}' || '$*TMPDIR'/, $tempdir, :g);
                 %config{$node.key} = $node.value.subst(/'{$*PID}' || '$*PID'/, $*PID, :g);
                 %config{$node.key} = $node.value.subst(/'{time}'/, time, :g);
             }


### PR DESCRIPTION
On macOS $*TMPDIR has a trailing / by default whereas on other OS it does not. This lead to zef output that would result in displaying paths with duplicated / like /tmp//foo/bar. This instead uses the absolute paths of those same objects which removes the unneeded trailing /