### PR TITLE
Avoid reusing subdirectory in temp path

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -1,7 +1,7 @@
 {
     "ConfigVersion" : "1",
     "StoreDir" : "$*HOME/.zef/store",
-    "TempDir"  : "$*TMPDIR/.zef/{time}.{$*PID}",
+    "TempDir"  : "$*TMPDIR/.zef.{time}.{$*PID}",
     "DefaultCUR" : ["auto"],
     "License" : {
         "whitelist" : "*",


### PR DESCRIPTION
Previously zef would use a temp directory like /tmp/.zef/[some-id], but that meant /tmp/.zef could be reused and thus have permissions for a different user. This updates zef to use a temp directory like /tmp/.zef.[some-id] such that subdirectory under /tmp will be created for each run and thus have permissions for the user running zef.

Resolves #563