### PR TITLE
Fix browse sub command error message

### DIFF
--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -894,7 +894,7 @@ package Zef::CLI {
         my $candi  = $client.resolve($identity).head
                 ||   $client.search($identity, :strict, :max-results(1))[0]\
                 ||   abort "!!!> Found no candidates matching identity: {$identity}";
-        my %support  = $candi.dist.meta<support>;
+        my %support  = $candi.dist.meta<support>.hash;
         my $url      = %support{$url-type};
         my @has-urls = grep { %support{$_} }, <homepage bugtracker source>;
         unless $url && $url.starts-with('http://' | 'https://') {


### PR DESCRIPTION
Previously when using `zef browse ...` with a distribution that does not have a "support" section in it's META6.json it would give an unhelpful error related to hash initialization. This fixes the issue by ensuring we have an empty hash.