### PR TITLE
Micro-optimize Zef::Distribution!long-name

### DIFF
--- a/lib/Zef/Distribution.rakumod
+++ b/lib/Zef/Distribution.rakumod
@@ -213,11 +213,11 @@ class Zef::Distribution does Distribution is Zef::Distribution::DependencySpecif
     }
 
     method !long-name($name --> Str) {
-        return sprintf '%s:ver<%s>:auth<%s>:api<%s>',
-            $name,
-            (self.ver  // ''),
-            (self.auth // '').trans(['<', '>'] => ['\<', '\>']),
-            (self.api  // ''),
+        return $name
+	    ~ ':ver<' ~ (self.ver // '')
+	    ~ '>:auth<' ~ (self.auth // '').trans(['<', '>'] => ['\<', '\>'])
+            ~ '>:api<' ~ (self.api  // '')
+            ~ '>'
         ;
     }
 


### PR DESCRIPTION
in pre-RakuAST, sprintf is relatively expensive. There's `use v6.e.PREVIEW` + `zprintf` which is a drop-in replacement for sprintf that doesn't have to redo the format parsing step, but I thought adding something like that to zef wouldn't be welcome.

I could only test it on my machine which is currently doing a relatively big unrelated workload, so my timings are possibly very inexact, but the time to do `zef list > /dev/null` (only removing terminal overhead by not printing so much) went from roughly 30s to 14s.

I have not measured the difference for other parts of zef, like zef install or so. I don't expect them to gain very much speed tbh.