### PR TITLE
Output commands run by Zef::Service::Shell::* wrappers

### DIFF
--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -584,7 +584,7 @@ class Zef::Client {
             die "failed to create directory: {$tmp.absolute}"
                 unless ($tmp.IO.e || mkdir($tmp));
 
-            my $meta6-prefix = '' R// $!extractor.ls-files($candi).sort.first({ .IO.basename eq 'META6.json' });
+            my $meta6-prefix = '' R// $!extractor.ls-files($candi, :$!logger).sort.first({ .IO.basename eq 'META6.json' });
 
             self.logger.emit({
                 level   => WARN,

--- a/lib/Zef/Service/Shell/DistributionBuilder.rakumod
+++ b/lib/Zef/Service/Shell/DistributionBuilder.rakumod
@@ -106,12 +106,11 @@ class Zef::Service::Shell::DistributionBuilder does Builder {
 
         my @exec = |($*EXECUTABLE.absolute, |@includes.grep(*.defined).map({ "-I{$_}" }), '-e', "$cmd");
 
-        $stdout.emit("Command: {@exec.join(' ')}");
-
         my $ENV := %*ENV;
         my $passed;
         react {
             my $proc = Zef::zrun-async(@exec, :w);
+            $stdout.emit("Command: {$proc.command}");
             whenever $proc.stdout.lines { $stdout.emit($_) }
             whenever $proc.stderr.lines { $stderr.emit($_) }
             whenever $proc.start(:$ENV, :cwd($dist.path)) { $passed = $_.so }

--- a/lib/Zef/Service/Shell/LegacyBuild.rakumod
+++ b/lib/Zef/Service/Shell/LegacyBuild.rakumod
@@ -88,12 +88,11 @@ class Zef::Service::Shell::LegacyBuild does Builder {
         my $cmd        = "require '$build-file'; ::('Build').new.build('$dist.path.IO.absolute()') ?? exit(0) !! exit(1);";
         my @exec       = |($*EXECUTABLE.absolute, |@includes.grep(*.defined).map({ "-I{$_}" }), '-e', "$cmd");
 
-        $stdout.emit("Command: {@exec.join(' ')}");
-
         my $ENV := %*ENV;
         my $passed;
         react {
             my $proc = Zef::zrun-async(@exec);
+            $stdout.emit("Command: {$proc.command}");
             whenever $proc.stdout.lines { $stdout.emit($_) }
             whenever $proc.stderr.lines { $stderr.emit($_) }
             whenever $proc.start(:$ENV, :cwd($dist.path)) { $passed = $_.so }

--- a/lib/Zef/Service/Shell/Test.rakumod
+++ b/lib/Zef/Service/Shell/Test.rakumod
@@ -92,6 +92,7 @@ class Zef::Service::Shell::Test does Tester {
             my $passed;
             react {
                 my $proc = Zef::zrun-async($*EXECUTABLE.absolute, @includes.map({ slip '-I', $_ }), $rel-test-file);
+                $stdout.emit("Command: {$proc.command}");
                 whenever $proc.stdout.lines { $stdout.emit($_) }
                 whenever $proc.stderr.lines { $stderr.emit($_) }
                 whenever $proc.start(:cwd($path)) { $passed = $_.so }

--- a/lib/Zef/Service/Shell/curl.rakumod
+++ b/lib/Zef/Service/Shell/curl.rakumod
@@ -106,6 +106,7 @@ class Zef::Service::Shell::curl does Fetcher does Probeable {
             my $ENV := %*ENV;
             my $cmd := self!command();
             my $proc = Zef::zrun-async($cmd, '--silent', '-L', '-z', $save-as.absolute, '-o', $save-as.absolute, $uri);
+            $stdout.emit("Command: {$proc.command}");
             whenever $proc.stdout(:bin) { }
             whenever $proc.stderr(:bin) { }
             whenever $proc.start(:$ENV, :$cwd) { $passed = $_.so }

--- a/lib/Zef/Service/Shell/wget.rakumod
+++ b/lib/Zef/Service/Shell/wget.rakumod
@@ -106,6 +106,7 @@ class Zef::Service::Shell::wget does Fetcher does Probeable {
             my $ENV := %*ENV;
             my $cmd := self!command();
             my $proc = Zef::zrun-async($cmd, '-P', $cwd, '--quiet', $uri, '-O', $save-as.absolute);
+            $stdout.emit("Command: {$proc.command}");
             whenever $proc.stdout(:bin) { }
             whenever $proc.stderr(:bin) { }
             whenever $proc.start(:$ENV, :$cwd) { $passed = $_.so }


### PR DESCRIPTION
Zef uses the curl, tar, unzip, and git commands to do various things. It can be useful to know how zef is using these tools when debugging, but there was no way for users to know what exactly they can run to emulate the behavior. This adds extra output when running zef with `--debug` that shows what any command zef runs is.