### PR TITLE
Avoid passing along Nils

### DIFF
--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -138,7 +138,7 @@ class Zef::Repository does PackageRepository does Pluggable {
 
             my $group-results := @repo-group.hyper(:batch(1)).map: -> $repo {
                 my @search-for = $repo.id eq 'Zef::Repository::LocalCache' ?? @identities !! @look-for;
-                $repo.search(@search-for, :strict);
+                $repo.search(@search-for, :strict).grep(*.so);
             }
 
             for $group-results.flat -> $dist {


### PR DESCRIPTION
Calling a non existent method on Nil returns Nil, which means `%x{$foo.as}` does not work as expected if `$foo` happens to be Nil. This filters our Nils from search results to avoid the aforementioned issue.

Resolves #568 