### PR TITLE
use v6.d

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,6 @@
 {
     "meta-version"  : "0",
-    "raku"          : "6.c",
+    "raku"          : "6.d",
     "name"          : "zef",
     "api"           : "0",
     "version"       : "0.22.8",

--- a/bin/zef
+++ b/bin/zef
@@ -1,3 +1,3 @@
 #!/usr/bin/env raku
-
+use v6.d;
 use Zef::CLI;

--- a/lib/Zef.rakumod
+++ b/lib/Zef.rakumod
@@ -1,3 +1,5 @@
+use v6.d;
+
 module Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '') {
     our sub zrun(*@_, *%_) is export { run (|@_).grep(*.?chars), |%_ }
     our sub zrun-async(*@_, *%_) is export { Proc::Async.new( (|@_).grep(*.?chars), |%_ ) }

--- a/lib/Zef/Build.rakumod
+++ b/lib/Zef/Build.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Client:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Config:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Config.rakumod
+++ b/lib/Zef/Config.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 module Zef::Config {

--- a/lib/Zef/Distribution.rakumod
+++ b/lib/Zef/Distribution.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Utils::SystemQuery:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Distribution/DependencySpecification.rakumod
+++ b/lib/Zef/Distribution/DependencySpecification.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Identity:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Distribution/Local.rakumod
+++ b/lib/Zef/Distribution/Local.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Extract.rakumod
+++ b/lib/Zef/Extract.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Fetch.rakumod
+++ b/lib/Zef/Fetch.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Identity.rakumod
+++ b/lib/Zef/Identity.rakumod
@@ -1,3 +1,5 @@
+use v6.d;
+
 class Zef::Identity {
     has $.name;
     has $.version;

--- a/lib/Zef/Install.rakumod
+++ b/lib/Zef/Install.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Report.rakumod
+++ b/lib/Zef/Report.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Report does Pluggable does Reporter {

--- a/lib/Zef/Repository.rakumod
+++ b/lib/Zef/Repository.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Repository does PackageRepository does Pluggable {

--- a/lib/Zef/Repository/Ecosystems.rakumod
+++ b/lib/Zef/Repository/Ecosystems.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Repository/LocalCache.rakumod
+++ b/lib/Zef/Repository/LocalCache.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::DependencySpecification:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);

--- a/lib/Zef/Service/FetchPath.rakumod
+++ b/lib/Zef/Service/FetchPath.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Service/FileReporter.rakumod
+++ b/lib/Zef/Service/FileReporter.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::FileReporter does Reporter {

--- a/lib/Zef/Service/InstallRakuDistribution.rakumod
+++ b/lib/Zef/Service/InstallRakuDistribution.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::InstallRakuDistribution does Installer {

--- a/lib/Zef/Service/Shell/DistributionBuilder.rakumod
+++ b/lib/Zef/Service/Shell/DistributionBuilder.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Service/Shell/LegacyBuild.rakumod
+++ b/lib/Zef/Service/Shell/LegacyBuild.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Distribution::Local:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Service/Shell/Test.rakumod
+++ b/lib/Zef/Service/Shell/Test.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Service/Shell/curl.rakumod
+++ b/lib/Zef/Service/Shell/curl.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::curl does Fetcher does Probeable {

--- a/lib/Zef/Service/Shell/git.rakumod
+++ b/lib/Zef/Service/Shell/git.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::URI:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth) :internals;
 

--- a/lib/Zef/Service/Shell/tar.rakumod
+++ b/lib/Zef/Service/Shell/tar.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 # Note: when passing command line arguments to tar in this module be sure to use relative

--- a/lib/Zef/Service/Shell/unzip.rakumod
+++ b/lib/Zef/Service/Shell/unzip.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::unzip does Extractor {

--- a/lib/Zef/Service/Shell/wget.rakumod
+++ b/lib/Zef/Service/Shell/wget.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Service::Shell::wget does Fetcher does Probeable {

--- a/lib/Zef/Service/TAP.rakumod
+++ b/lib/Zef/Service/TAP.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 use Zef::Utils::FileSystem:ver(Zef.^ver):api(Zef.^api):auth(Zef.^auth);
 

--- a/lib/Zef/Test.rakumod
+++ b/lib/Zef/Test.rakumod
@@ -1,3 +1,4 @@
+use v6.d;
 use Zef:ver($?DISTRIBUTION.meta<version> // $?DISTRIBUTION.meta<ver>// '*'):api($?DISTRIBUTION.meta<api> // '*'):auth($?DISTRIBUTION.meta<auth> // '');
 
 class Zef::Test does Tester does Pluggable {

--- a/lib/Zef/Utils/FileSystem.rakumod
+++ b/lib/Zef/Utils/FileSystem.rakumod
@@ -1,3 +1,5 @@
+use v6.d;
+
 module Zef::Utils::FileSystem {
 
     =begin pod

--- a/lib/Zef/Utils/SystemQuery.rakumod
+++ b/lib/Zef/Utils/SystemQuery.rakumod
@@ -1,3 +1,5 @@
+use v6.d;
+
 module Zef::Utils::SystemQuery {
 
     =begin pod

--- a/lib/Zef/Utils/URI.rakumod
+++ b/lib/Zef/Utils/URI.rakumod
@@ -1,3 +1,5 @@
+use v6.d;
+
 class Zef::Utils::URI {
     has $.is-relative;
     has $.match;

--- a/t/00-load.rakutest
+++ b/t/00-load.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 2;
 

--- a/t/build.rakutest
+++ b/t/build.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 1;
 

--- a/t/distribution-depends-parsing.rakutest
+++ b/t/distribution-depends-parsing.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 35;
 

--- a/t/extract.rakutest
+++ b/t/extract.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 1;
 

--- a/t/fetch.rakutest
+++ b/t/fetch.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 1;
 

--- a/t/identity.rakutest
+++ b/t/identity.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 6;
 

--- a/t/install.rakutest
+++ b/t/install.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 1;
 

--- a/t/repository.rakutest
+++ b/t/repository.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 1;
 

--- a/t/test.rakutest
+++ b/t/test.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 1;
 

--- a/t/utils-filesystem.rakutest
+++ b/t/utils-filesystem.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 4;
 

--- a/xt/install.rakutest
+++ b/xt/install.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 3;
 

--- a/xt/repository.rakutest
+++ b/xt/repository.rakutest
@@ -1,3 +1,4 @@
+use v6.d;
 use Test;
 plan 5;
 


### PR DESCRIPTION
Zef could not start using v6.d immediately since people were still using older rakudos that did not provide it. That was a long time ago and any version of zef one might consider recent would not work on such old rakudos anymore (primarily due to the existence of CompUnit::Repository::Staging). As such, this commit makes zef use v6.d.