### PR TITLE
Make script path more readable in post install message

### DIFF
--- a/lib/Zef/Client.rakumod
+++ b/lib/Zef/Client.rakumod
@@ -1044,7 +1044,7 @@ class Zef::Client {
 
                 if @installed-candidates.map(*.dist).map(*.&bin-names).flat.unique -> @bins {
                     my $msg = "\n{+@bins} bin/ script{+@bins>1??'s'!!''}{+@bins??' ['~@bins~']'!!''} installed to:"
-                    ~ "\n" ~ @curs.map(*.prefix.child('bin')).join("\n");
+                    ~ "\n" ~ @curs.map(*.prefix.resolve.child('bin')).join("\n");
                     self.logger.emit({
                         level   => INFO,
                         stage   => REPORT,


### PR DESCRIPTION
The message sometimes reads:

1 bin/ script [terminal-test] installed to:
C:\rakudo\share\perl6\site\bin\..\..\..\..\share\perl6\site\bin

Some users find all those updirs a bit confusing. Solve by resolving that path.