### PR TITLE
Empy string value in ZEF_INSTALL_TO is ignored

### DIFF
--- a/lib/Zef/CLI.rakumod
+++ b/lib/Zef/CLI.rakumod
@@ -132,7 +132,7 @@ package Zef::CLI {
             Bool :$contained,
             :$update,
             :$exclude,
-            :to(:$install-to) = %*ENV<ZEF_INSTALL_TO> // $CONFIG<DefaultCUR>,
+            :to(:$install-to) = %*ENV<ZEF_INSTALL_TO> || $CONFIG<DefaultCUR>,
             *@wants ($, *@)
         )
 
@@ -427,7 +427,7 @@ package Zef::CLI {
         Bool :$contained,
         :$update,
         :$exclude,
-        :to(:$install-to) = %*ENV<ZEF_INSTALL_TO> // $CONFIG<DefaultCUR>,
+        :to(:$install-to) = %*ENV<ZEF_INSTALL_TO> || $CONFIG<DefaultCUR>,
         *@wants ($, *@)
     ) {
         @wants = @wants.map({ $_ eq '-' ?? $*IN.lines.Slip !! $_ }).unique;
@@ -607,7 +607,7 @@ package Zef::CLI {
         Bool :$update,
         Bool :$serial,
         :$exclude,
-        :to(:$install-to) = %*ENV<ZEF_INSTALL_TO> // $CONFIG<DefaultCUR>,
+        :to(:$install-to) = %*ENV<ZEF_INSTALL_TO> || $CONFIG<DefaultCUR>,
         *@identities
     ) {
         @identities = @identities.map({ $_ eq '-' ?? $*IN.lines.Slip !! $_ }).unique;
@@ -953,7 +953,7 @@ package Zef::CLI {
         Bool :$dry,
         Bool :$serial,
         :$exclude,
-        :to(:$install-to) = %*ENV<ZEF_INSTALL_TO> // $CONFIG<DefaultCUR>,
+        :to(:$install-to) = %*ENV<ZEF_INSTALL_TO> || $CONFIG<DefaultCUR>,
     ) {
         my $client = get-client(
             :config($CONFIG), :exclude($exclude.grep(*.defined).map({ Zef::Distribution::DependencySpecification.new($_) })),


### PR DESCRIPTION
Previously if `ZEF_INSTALL_TO` was set to an empty string "" it would consider that empty string to be the path of the install target, which isn't what users will expect. This change makes it so an empty string is the same as it not being set at all.