### PR TITLE
Only use tap harness when explicitly requested

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -143,13 +143,14 @@
     ],
     "Test" : [
         {
-            "short-name" : "tap-harness",
-            "module" : "Zef::Service::TAP",
-            "comment" : "Raku TAP::Harness adapter"
-        },
-        {
             "short-name" : "raku-test",
             "module" : "Zef::Service::Shell::Test"
+        },
+        {
+            "short-name" : "tap-harness",
+            "module" : "Zef::Service::TAP",
+            "comment" : "Raku TAP::Harness adapter",
+            "enabled" : 0
         }
     ]
 }


### PR DESCRIPTION
Previously zef would use `TAP::Harness` for testing if it was installed. However this can often be confusing when trying to debug issues since reproducibility requires knowledge of that plugin being used at all. This change makes it so tap harness will only be used when explicitly requested via the existing `--tap-harness` option